### PR TITLE
Allow examples to compile on a Mac

### DIFF
--- a/examples/common.pro
+++ b/examples/common.pro
@@ -23,7 +23,9 @@ win32{
     LIBS += -L../../lib -lqwtplot3d -lopengl32 -lglu32 -lgdi32
 }
 
-unix:LIBS += -L../../lib -lqwtplot3d -lGLU
+unix:!macx { LIBS += -L../../lib -lqwtplot3d -lGLU }
+
+macx: LIBS += -L../../lib -lqwtplot3d -framework OpenGL
 
 linux-g++:QMAKE_CXXFLAGS += -fno-exceptions
 


### PR DESCRIPTION
If compiling on Mac 10.10 this fails trying to find -lGLU.

Change allows examples to be built on a Mac
