### PR TITLE
Q_OBJECT in class plot shoud be deleted

### DIFF
--- a/examples/mesh/src/lightingdialog.h
+++ b/examples/mesh/src/lightingdialog.h
@@ -36,7 +36,7 @@ typedef Qwt3D::GridPlot SPlot; // moc/VC6 issue in Qt4
 
 class Plot : public SPlot
 {
-  Q_OBJECT
+//  Q_OBJECT
     
 public:
   Plot(QWidget* parent);


### PR DESCRIPTION
The mesh project can not  run with raw source, but after I delete Q_OBJECT in class plot , it successfully run.
ERROR: moc_lightingdialog.obj:-1: error: LNK2001: unresolved external symbol "public: static struct QMetaObject const Qwt3D::GridPlot::staticMetaObject" (?staticMetaObject@GridPlot@Qwt3D@@2UQMetaObject@@B).
Environment: win10, 64bit, vs2013, qt5.5.1-64bit.