### PR TITLE
Support for building from Qt Creator using MSVC 2015 compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@
 *.app
 *.idb
 *.user
+
+# Visual Studio 2015 temporaries
+.v*
+*.user
+*.VC.db
+*.vcxproj.user
+
+

--- a/GeneratedFiles/moc_qwt3d_extglwidget.cpp
+++ b/GeneratedFiles/moc_qwt3d_extglwidget.cpp
@@ -1,0 +1,328 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qwt3d_extglwidget.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../include/qwt3d_extglwidget.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qwt3d_extglwidget.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.9.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_Qwt3D__ExtGLWidget_t {
+    QByteArrayData data[36];
+    char stringdata0[380];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_Qwt3D__ExtGLWidget_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_Qwt3D__ExtGLWidget_t qt_meta_stringdata_Qwt3D__ExtGLWidget = {
+    {
+QT_MOC_LITERAL(0, 0, 18), // "Qwt3D::ExtGLWidget"
+QT_MOC_LITERAL(1, 19, 15), // "rotationChanged"
+QT_MOC_LITERAL(2, 35, 0), // ""
+QT_MOC_LITERAL(3, 36, 6), // "xAngle"
+QT_MOC_LITERAL(4, 43, 6), // "yAngle"
+QT_MOC_LITERAL(5, 50, 6), // "zAngle"
+QT_MOC_LITERAL(6, 57, 12), // "shiftChanged"
+QT_MOC_LITERAL(7, 70, 6), // "xShift"
+QT_MOC_LITERAL(8, 77, 6), // "yShift"
+QT_MOC_LITERAL(9, 84, 6), // "zShift"
+QT_MOC_LITERAL(10, 91, 19), // "vieportShiftChanged"
+QT_MOC_LITERAL(11, 111, 12), // "scaleChanged"
+QT_MOC_LITERAL(12, 124, 6), // "xScale"
+QT_MOC_LITERAL(13, 131, 6), // "yScale"
+QT_MOC_LITERAL(14, 138, 6), // "zScale"
+QT_MOC_LITERAL(15, 145, 11), // "zoomChanged"
+QT_MOC_LITERAL(16, 157, 17), // "projectionChanged"
+QT_MOC_LITERAL(17, 175, 11), // "setRotation"
+QT_MOC_LITERAL(18, 187, 4), // "xVal"
+QT_MOC_LITERAL(19, 192, 4), // "yVal"
+QT_MOC_LITERAL(20, 197, 4), // "zVal"
+QT_MOC_LITERAL(21, 202, 8), // "setShift"
+QT_MOC_LITERAL(22, 211, 16), // "setViewportShift"
+QT_MOC_LITERAL(23, 228, 8), // "setScale"
+QT_MOC_LITERAL(24, 237, 7), // "setZoom"
+QT_MOC_LITERAL(25, 245, 8), // "setOrtho"
+QT_MOC_LITERAL(26, 254, 11), // "enableMouse"
+QT_MOC_LITERAL(27, 266, 3), // "val"
+QT_MOC_LITERAL(28, 270, 12), // "disableMouse"
+QT_MOC_LITERAL(29, 283, 14), // "enableKeyboard"
+QT_MOC_LITERAL(30, 298, 15), // "disableKeyboard"
+QT_MOC_LITERAL(31, 314, 14), // "enableLighting"
+QT_MOC_LITERAL(32, 329, 15), // "disableLighting"
+QT_MOC_LITERAL(33, 345, 16), // "setLightRotation"
+QT_MOC_LITERAL(34, 362, 3), // "idx"
+QT_MOC_LITERAL(35, 366, 13) // "setLightShift"
+
+    },
+    "Qwt3D::ExtGLWidget\0rotationChanged\0\0"
+    "xAngle\0yAngle\0zAngle\0shiftChanged\0"
+    "xShift\0yShift\0zShift\0vieportShiftChanged\0"
+    "scaleChanged\0xScale\0yScale\0zScale\0"
+    "zoomChanged\0projectionChanged\0setRotation\0"
+    "xVal\0yVal\0zVal\0setShift\0setViewportShift\0"
+    "setScale\0setZoom\0setOrtho\0enableMouse\0"
+    "val\0disableMouse\0enableKeyboard\0"
+    "disableKeyboard\0enableLighting\0"
+    "disableLighting\0setLightRotation\0idx\0"
+    "setLightShift"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_Qwt3D__ExtGLWidget[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+      28,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       6,       // signalCount
+
+ // signals: name, argc, parameters, tag, flags
+       1,    3,  154,    2, 0x06 /* Public */,
+       6,    3,  161,    2, 0x06 /* Public */,
+      10,    2,  168,    2, 0x06 /* Public */,
+      11,    3,  173,    2, 0x06 /* Public */,
+      15,    1,  180,    2, 0x06 /* Public */,
+      16,    1,  183,    2, 0x06 /* Public */,
+
+ // slots: name, argc, parameters, tag, flags
+      17,    3,  186,    2, 0x0a /* Public */,
+      21,    3,  193,    2, 0x0a /* Public */,
+      22,    2,  200,    2, 0x0a /* Public */,
+      23,    3,  205,    2, 0x0a /* Public */,
+      24,    1,  212,    2, 0x0a /* Public */,
+      25,    1,  215,    2, 0x0a /* Public */,
+      26,    1,  218,    2, 0x0a /* Public */,
+      26,    0,  221,    2, 0x2a /* Public | MethodCloned */,
+      28,    1,  222,    2, 0x0a /* Public */,
+      28,    0,  225,    2, 0x2a /* Public | MethodCloned */,
+      29,    1,  226,    2, 0x0a /* Public */,
+      29,    0,  229,    2, 0x2a /* Public | MethodCloned */,
+      30,    1,  230,    2, 0x0a /* Public */,
+      30,    0,  233,    2, 0x2a /* Public | MethodCloned */,
+      31,    1,  234,    2, 0x0a /* Public */,
+      31,    0,  237,    2, 0x2a /* Public | MethodCloned */,
+      32,    1,  238,    2, 0x0a /* Public */,
+      32,    0,  241,    2, 0x2a /* Public | MethodCloned */,
+      33,    4,  242,    2, 0x0a /* Public */,
+      33,    3,  251,    2, 0x2a /* Public | MethodCloned */,
+      35,    4,  258,    2, 0x0a /* Public */,
+      35,    3,  267,    2, 0x2a /* Public | MethodCloned */,
+
+ // signals: parameters
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,    3,    4,    5,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,    7,    8,    9,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double,    7,    8,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   12,   13,   14,
+    QMetaType::Void, QMetaType::Double,    2,
+    QMetaType::Void, QMetaType::Bool,    2,
+
+ // slots: parameters
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   18,   19,   20,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   18,   19,   20,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double,   18,   19,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   18,   19,   20,
+    QMetaType::Void, QMetaType::Double,    2,
+    QMetaType::Void, QMetaType::Bool,    2,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Bool,   27,
+    QMetaType::Void,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double, QMetaType::UInt,   18,   19,   20,   34,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   18,   19,   20,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double, QMetaType::UInt,   18,   19,   20,   34,
+    QMetaType::Void, QMetaType::Double, QMetaType::Double, QMetaType::Double,   18,   19,   20,
+
+       0        // eod
+};
+
+void Qwt3D::ExtGLWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        ExtGLWidget *_t = static_cast<ExtGLWidget *>(_o);
+        Q_UNUSED(_t)
+        switch (_id) {
+        case 0: _t->rotationChanged((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 1: _t->shiftChanged((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 2: _t->vieportShiftChanged((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2]))); break;
+        case 3: _t->scaleChanged((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 4: _t->zoomChanged((*reinterpret_cast< double(*)>(_a[1]))); break;
+        case 5: _t->projectionChanged((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 6: _t->setRotation((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 7: _t->setShift((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 8: _t->setViewportShift((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2]))); break;
+        case 9: _t->setScale((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 10: _t->setZoom((*reinterpret_cast< double(*)>(_a[1]))); break;
+        case 11: _t->setOrtho((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 12: _t->enableMouse((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 13: _t->enableMouse(); break;
+        case 14: _t->disableMouse((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 15: _t->disableMouse(); break;
+        case 16: _t->enableKeyboard((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 17: _t->enableKeyboard(); break;
+        case 18: _t->disableKeyboard((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 19: _t->disableKeyboard(); break;
+        case 20: _t->enableLighting((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 21: _t->enableLighting(); break;
+        case 22: _t->disableLighting((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 23: _t->disableLighting(); break;
+        case 24: _t->setLightRotation((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3])),(*reinterpret_cast< uint(*)>(_a[4]))); break;
+        case 25: _t->setLightRotation((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        case 26: _t->setLightShift((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3])),(*reinterpret_cast< uint(*)>(_a[4]))); break;
+        case 27: _t->setLightShift((*reinterpret_cast< double(*)>(_a[1])),(*reinterpret_cast< double(*)>(_a[2])),(*reinterpret_cast< double(*)>(_a[3]))); break;
+        default: ;
+        }
+    } else if (_c == QMetaObject::IndexOfMethod) {
+        int *result = reinterpret_cast<int *>(_a[0]);
+        void **func = reinterpret_cast<void **>(_a[1]);
+        {
+            typedef void (ExtGLWidget::*_t)(double , double , double );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::rotationChanged)) {
+                *result = 0;
+                return;
+            }
+        }
+        {
+            typedef void (ExtGLWidget::*_t)(double , double , double );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::shiftChanged)) {
+                *result = 1;
+                return;
+            }
+        }
+        {
+            typedef void (ExtGLWidget::*_t)(double , double );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::vieportShiftChanged)) {
+                *result = 2;
+                return;
+            }
+        }
+        {
+            typedef void (ExtGLWidget::*_t)(double , double , double );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::scaleChanged)) {
+                *result = 3;
+                return;
+            }
+        }
+        {
+            typedef void (ExtGLWidget::*_t)(double );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::zoomChanged)) {
+                *result = 4;
+                return;
+            }
+        }
+        {
+            typedef void (ExtGLWidget::*_t)(bool );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&ExtGLWidget::projectionChanged)) {
+                *result = 5;
+                return;
+            }
+        }
+    }
+}
+
+const QMetaObject Qwt3D::ExtGLWidget::staticMetaObject = {
+    { &QGLWidget::staticMetaObject, qt_meta_stringdata_Qwt3D__ExtGLWidget.data,
+      qt_meta_data_Qwt3D__ExtGLWidget,  qt_static_metacall, nullptr, nullptr}
+};
+
+
+const QMetaObject *Qwt3D::ExtGLWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *Qwt3D::ExtGLWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_Qwt3D__ExtGLWidget.stringdata0))
+        return static_cast<void*>(const_cast< ExtGLWidget*>(this));
+    return QGLWidget::qt_metacast(_clname);
+}
+
+int Qwt3D::ExtGLWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QGLWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 28)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 28;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 28)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 28;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void Qwt3D::ExtGLWidget::rotationChanged(double _t1, double _t2, double _t3)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+
+// SIGNAL 1
+void Qwt3D::ExtGLWidget::shiftChanged(double _t1, double _t2, double _t3)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 1, _a);
+}
+
+// SIGNAL 2
+void Qwt3D::ExtGLWidget::vieportShiftChanged(double _t1, double _t2)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 2, _a);
+}
+
+// SIGNAL 3
+void Qwt3D::ExtGLWidget::scaleChanged(double _t1, double _t2, double _t3)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)), const_cast<void*>(reinterpret_cast<const void*>(&_t3)) };
+    QMetaObject::activate(this, &staticMetaObject, 3, _a);
+}
+
+// SIGNAL 4
+void Qwt3D::ExtGLWidget::zoomChanged(double _t1)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 4, _a);
+}
+
+// SIGNAL 5
+void Qwt3D::ExtGLWidget::projectionChanged(bool _t1)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 5, _a);
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/GeneratedFiles/moc_qwt3d_gridplot.cpp
+++ b/GeneratedFiles/moc_qwt3d_gridplot.cpp
@@ -1,0 +1,139 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qwt3d_gridplot.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../include/qwt3d_gridplot.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qwt3d_gridplot.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.9.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_Qwt3D__GridPlot_t {
+    QByteArrayData data[4];
+    char stringdata0[49];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_Qwt3D__GridPlot_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_Qwt3D__GridPlot_t qt_meta_stringdata_Qwt3D__GridPlot = {
+    {
+QT_MOC_LITERAL(0, 0, 15), // "Qwt3D::GridPlot"
+QT_MOC_LITERAL(1, 16, 17), // "resolutionChanged"
+QT_MOC_LITERAL(2, 34, 0), // ""
+QT_MOC_LITERAL(3, 35, 13) // "setResolution"
+
+    },
+    "Qwt3D::GridPlot\0resolutionChanged\0\0"
+    "setResolution"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_Qwt3D__GridPlot[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: name, argc, parameters, tag, flags
+       1,    1,   24,    2, 0x06 /* Public */,
+
+ // slots: name, argc, parameters, tag, flags
+       3,    1,   27,    2, 0x0a /* Public */,
+
+ // signals: parameters
+    QMetaType::Void, QMetaType::Int,    2,
+
+ // slots: parameters
+    QMetaType::Void, QMetaType::Int,    2,
+
+       0        // eod
+};
+
+void Qwt3D::GridPlot::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        GridPlot *_t = static_cast<GridPlot *>(_o);
+        Q_UNUSED(_t)
+        switch (_id) {
+        case 0: _t->resolutionChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 1: _t->setResolution((*reinterpret_cast< int(*)>(_a[1]))); break;
+        default: ;
+        }
+    } else if (_c == QMetaObject::IndexOfMethod) {
+        int *result = reinterpret_cast<int *>(_a[0]);
+        void **func = reinterpret_cast<void **>(_a[1]);
+        {
+            typedef void (GridPlot::*_t)(int );
+            if (*reinterpret_cast<_t *>(func) == static_cast<_t>(&GridPlot::resolutionChanged)) {
+                *result = 0;
+                return;
+            }
+        }
+    }
+}
+
+const QMetaObject Qwt3D::GridPlot::staticMetaObject = {
+    { &SurfacePlot::staticMetaObject, qt_meta_stringdata_Qwt3D__GridPlot.data,
+      qt_meta_data_Qwt3D__GridPlot,  qt_static_metacall, nullptr, nullptr}
+};
+
+
+const QMetaObject *Qwt3D::GridPlot::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *Qwt3D::GridPlot::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_Qwt3D__GridPlot.stringdata0))
+        return static_cast<void*>(const_cast< GridPlot*>(this));
+    return SurfacePlot::qt_metacast(_clname);
+}
+
+int Qwt3D::GridPlot::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = SurfacePlot::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 2)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void Qwt3D::GridPlot::resolutionChanged(int _t1)
+{
+    void *_a[] = { nullptr, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/GeneratedFiles/moc_qwt3d_plot3d.cpp
+++ b/GeneratedFiles/moc_qwt3d_plot3d.cpp
@@ -1,0 +1,116 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qwt3d_plot3d.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../include/qwt3d_plot3d.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qwt3d_plot3d.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.9.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_Qwt3D__Plot3D_t {
+    QByteArrayData data[5];
+    char stringdata0[36];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_Qwt3D__Plot3D_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_Qwt3D__Plot3D_t qt_meta_stringdata_Qwt3D__Plot3D = {
+    {
+QT_MOC_LITERAL(0, 0, 13), // "Qwt3D::Plot3D"
+QT_MOC_LITERAL(1, 14, 4), // "save"
+QT_MOC_LITERAL(2, 19, 0), // ""
+QT_MOC_LITERAL(3, 20, 8), // "fileName"
+QT_MOC_LITERAL(4, 29, 6) // "format"
+
+    },
+    "Qwt3D::Plot3D\0save\0\0fileName\0format"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_Qwt3D__Plot3D[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: name, argc, parameters, tag, flags
+       1,    2,   19,    2, 0x0a /* Public */,
+
+ // slots: parameters
+    QMetaType::Bool, QMetaType::QString, QMetaType::QString,    3,    4,
+
+       0        // eod
+};
+
+void Qwt3D::Plot3D::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Plot3D *_t = static_cast<Plot3D *>(_o);
+        Q_UNUSED(_t)
+        switch (_id) {
+        case 0: { bool _r = _t->save((*reinterpret_cast< const QString(*)>(_a[1])),(*reinterpret_cast< const QString(*)>(_a[2])));
+            if (_a[0]) *reinterpret_cast< bool*>(_a[0]) = std::move(_r); }  break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObject Qwt3D::Plot3D::staticMetaObject = {
+    { &ExtGLWidget::staticMetaObject, qt_meta_stringdata_Qwt3D__Plot3D.data,
+      qt_meta_data_Qwt3D__Plot3D,  qt_static_metacall, nullptr, nullptr}
+};
+
+
+const QMetaObject *Qwt3D::Plot3D::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *Qwt3D::Plot3D::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_Qwt3D__Plot3D.stringdata0))
+        return static_cast<void*>(const_cast< Plot3D*>(this));
+    return ExtGLWidget::qt_metacast(_clname);
+}
+
+int Qwt3D::Plot3D::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ExtGLWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 1)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 1;
+    }
+    return _id;
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/GeneratedFiles/moc_qwt3d_surfaceplot.cpp
+++ b/GeneratedFiles/moc_qwt3d_surfaceplot.cpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'qwt3d_surfaceplot.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../include/qwt3d_surfaceplot.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'qwt3d_surfaceplot.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.9.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_Qwt3D__SurfacePlot_t {
+    QByteArrayData data[1];
+    char stringdata0[19];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_Qwt3D__SurfacePlot_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_Qwt3D__SurfacePlot_t qt_meta_stringdata_Qwt3D__SurfacePlot = {
+    {
+QT_MOC_LITERAL(0, 0, 18) // "Qwt3D::SurfacePlot"
+
+    },
+    "Qwt3D::SurfacePlot"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_Qwt3D__SurfacePlot[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       0,    0, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+       0        // eod
+};
+
+void Qwt3D::SurfacePlot::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    Q_UNUSED(_o);
+    Q_UNUSED(_id);
+    Q_UNUSED(_c);
+    Q_UNUSED(_a);
+}
+
+const QMetaObject Qwt3D::SurfacePlot::staticMetaObject = {
+    { &Plot3D::staticMetaObject, qt_meta_stringdata_Qwt3D__SurfacePlot.data,
+      qt_meta_data_Qwt3D__SurfacePlot,  qt_static_metacall, nullptr, nullptr}
+};
+
+
+const QMetaObject *Qwt3D::SurfacePlot::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *Qwt3D::SurfacePlot::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_Qwt3D__SurfacePlot.stringdata0))
+        return static_cast<void*>(const_cast< SurfacePlot*>(this));
+    return Plot3D::qt_metacast(_clname);
+}
+
+int Qwt3D::SurfacePlot::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = Plot3D::qt_metacall(_c, _id, _a);
+    return _id;
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/examples/autoswitch/GeneratedFiles/moc_autoswitch.cpp
+++ b/examples/autoswitch/GeneratedFiles/moc_autoswitch.cpp
@@ -1,0 +1,114 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'autoswitch.h'
+**
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.0)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "../autoswitch.h"
+#include <QtCore/qbytearray.h>
+#include <QtCore/qmetatype.h>
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'autoswitch.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 67
+#error "This file was generated using the moc from 5.9.0. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+struct qt_meta_stringdata_Plot_t {
+    QByteArrayData data[3];
+    char stringdata0[13];
+};
+#define QT_MOC_LITERAL(idx, ofs, len) \
+    Q_STATIC_BYTE_ARRAY_DATA_HEADER_INITIALIZER_WITH_OFFSET(len, \
+    qptrdiff(offsetof(qt_meta_stringdata_Plot_t, stringdata0) + ofs \
+        - idx * sizeof(QByteArrayData)) \
+    )
+static const qt_meta_stringdata_Plot_t qt_meta_stringdata_Plot = {
+    {
+QT_MOC_LITERAL(0, 0, 4), // "Plot"
+QT_MOC_LITERAL(1, 5, 6), // "rotate"
+QT_MOC_LITERAL(2, 12, 0) // ""
+
+    },
+    "Plot\0rotate\0"
+};
+#undef QT_MOC_LITERAL
+
+static const uint qt_meta_data_Plot[] = {
+
+ // content:
+       7,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: name, argc, parameters, tag, flags
+       1,    0,   19,    2, 0x0a /* Public */,
+
+ // slots: parameters
+    QMetaType::Void,
+
+       0        // eod
+};
+
+void Plot::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Plot *_t = static_cast<Plot *>(_o);
+        Q_UNUSED(_t)
+        switch (_id) {
+        case 0: _t->rotate(); break;
+        default: ;
+        }
+    }
+    Q_UNUSED(_a);
+}
+
+const QMetaObject Plot::staticMetaObject = {
+    { &GridPlot::staticMetaObject, qt_meta_stringdata_Plot.data,
+      qt_meta_data_Plot,  qt_static_metacall, nullptr, nullptr}
+};
+
+
+const QMetaObject *Plot::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->dynamicMetaObject() : &staticMetaObject;
+}
+
+void *Plot::qt_metacast(const char *_clname)
+{
+    if (!_clname) return nullptr;
+    if (!strcmp(_clname, qt_meta_stringdata_Plot.stringdata0))
+        return static_cast<void*>(const_cast< Plot*>(this));
+    return GridPlot::qt_metacast(_clname);
+}
+
+int Plot::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = GridPlot::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    } else if (_c == QMetaObject::RegisterMethodArgumentMetaType) {
+        if (_id < 1)
+            *reinterpret_cast<int*>(_a[0]) = -1;
+        _id -= 1;
+    }
+    return _id;
+}
+QT_WARNING_POP
+QT_END_MOC_NAMESPACE

--- a/examples/autoswitch/autoswitch-vc2015.vcxproj
+++ b/examples/autoswitch/autoswitch-vc2015.vcxproj
@@ -1,0 +1,163 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="autoswitch.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QT64)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Moc%27ing autoswitch.h...</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing autoswitch.h...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\include"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QT64)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Moc%27ing autoswitch.h...</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing autoswitch.h...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\include"</Command>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="autoswitch.cpp" />
+    <ClCompile Include="GeneratedFiles\moc_autoswitch.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B12702AD-ABFB-343A-A199-8E24837244A3}</ProjectGuid>
+    <Keyword>Qt4VSv1.0</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\bin\</OutDir>
+    <IntDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\bin\</OutDir>
+    <IntDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\bin\</OutDir>
+    <IntDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\bin\</OutDir>
+    <IntDir>..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>UNICODE;WIN32;WIN64;QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_OPENGL_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\GeneratedFiles;.;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL;$(QT32)\include\QtWidgets;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
+      <AdditionalLibraryDirectories>$(QT32)\lib;..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>qwtplot3d.lib;qtmaind.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5OpenGLd.lib;opengl32.lib;glu32.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>UNICODE;WIN32;WIN64;QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_OPENGL_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\GeneratedFiles;.;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL;$(QT32)\include\QtWidgets;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
+      <AdditionalLibraryDirectories>$(QT64)\lib;..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>qwtplot3d.lib;qtmaind.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5OpenGLd.lib;opengl32.lib;glu32.lib;Qt5Widgetsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>UNICODE;WIN32;WIN64;QT_DLL;QT_NO_DEBUG;NDEBUG;QT_CORE_LIB;QT_GUI_LIB;QT_OPENGL_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\GeneratedFiles;.;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL;$(QT32)\include\QtWidgets;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat />
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
+      <AdditionalLibraryDirectories>$(QT32)\lib;..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <AdditionalDependencies>qwtplot3d.lib;qtmain.lib;Qt5Core.lib;Qt5Gui.lib;Qt5OpenGL.lib;opengl32.lib;glu32.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>UNICODE;WIN32;WIN64;QT_DLL;QT_NO_DEBUG;NDEBUG;QT_CORE_LIB;QT_GUI_LIB;QT_OPENGL_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\GeneratedFiles;.;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL;$(QT32)\include\QtWidgets;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>
+      </DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
+      <AdditionalLibraryDirectories>$(QT64)\lib;..\..\..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <AdditionalDependencies>qwtplot3d.lib;qtmain.lib;Qt5Core.lib;Qt5Gui.lib;Qt5OpenGL.lib;opengl32.lib;glu32.lib;Qt5Widgets.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties MocDir=".\GeneratedFiles" UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" lupdateOptions="" lupdateOnBuild="0" lreleaseOptions="" Qt5Version_x0020_Win32="msvc2015" MocOptions="" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/examples/autoswitch/autoswitch-vc2015.vcxproj.filters
+++ b/examples/autoswitch/autoswitch-vc2015.vcxproj.filters
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{D9D6E242-F8AF-46E4-B9FD-80ECBC20BA3E}</UniqueIdentifier>
+      <Extensions>qrc;*</Extensions>
+      <ParseFiles>false</ParseFiles>
+    </Filter>
+    <Filter Include="Form Files">
+      <UniqueIdentifier>{99349809-55BA-4b9d-BF79-8FDBB0286EB3}</UniqueIdentifier>
+      <Extensions>ui</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{D9D6E242-F8AF-46E4-B9FD-80ECBC20BA3E}</UniqueIdentifier>
+      <Extensions>qrc;*</Extensions>
+      <ParseFiles>false</ParseFiles>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{71ED8ED8-ACB9-4CE9-BBE1-E00B30144E11}</UniqueIdentifier>
+      <Extensions>moc;h;cpp</Extensions>
+      <SourceControlFiles>False</SourceControlFiles>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="autoswitch.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="autoswitch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="GeneratedFiles\moc_autoswitch.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/examples/common.pro
+++ b/examples/common.pro
@@ -9,13 +9,7 @@ DEPENDPATH	= $$INCLUDEPATH
 DESTDIR = ../bin
 
 win32{
-  !build_pass {
-    win32-msvc | win32-msvc2002 {
-      error(Unsupported Visual Studio version ( < 2003 ))
-    }
-  }
-
-  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 {
+  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 | win32-msvc2015 {
     QMAKE_CXXFLAGS += -MP
     QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
   }

--- a/qwtplot3d-vc2015.sln
+++ b/qwtplot3d-vc2015.sln
@@ -1,0 +1,45 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qwtplot3d-vc2015", "qwtplot3d-vc2015.vcxproj", "{40CD35CA-3D02-446C-A457-5461316E0BD9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{00036FC7-C99E-4C2E-A62C-E5C1EC2726F2}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "autoswitch-vc2015", "examples\autoswitch\autoswitch-vc2015.vcxproj", "{B12702AD-ABFB-343A-A199-8E24837244A3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{40CD35CA-3D02-446C-A457-5461316E0BD9} = {40CD35CA-3D02-446C-A457-5461316E0BD9}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Debug|x64.ActiveCfg = Debug|x64
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Debug|x64.Build.0 = Debug|x64
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Debug|x86.ActiveCfg = Debug|Win32
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Debug|x86.Build.0 = Debug|Win32
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Release|x64.ActiveCfg = Release|x64
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Release|x64.Build.0 = Release|x64
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Release|x86.ActiveCfg = Release|Win32
+		{40CD35CA-3D02-446C-A457-5461316E0BD9}.Release|x86.Build.0 = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.ActiveCfg = Debug|x64
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.Build.0 = Debug|x64
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.ActiveCfg = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.Build.0 = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.ActiveCfg = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.ActiveCfg = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B12702AD-ABFB-343A-A199-8E24837244A3} = {00036FC7-C99E-4C2E-A62C-E5C1EC2726F2}
+	EndGlobalSection
+EndGlobal

--- a/qwtplot3d-vc2015.vcxproj
+++ b/qwtplot3d-vc2015.vcxproj
@@ -1,0 +1,308 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_extglwidget.cpp" />
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_gridplot.cpp" />
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_plot3d.cpp" />
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_surfaceplot.cpp" />
+    <ClCompile Include="src\qwt3d_appearance.cpp" />
+    <ClCompile Include="src\qwt3d_autoscaler.cpp" />
+    <ClCompile Include="src\qwt3d_axis.cpp" />
+    <ClCompile Include="src\qwt3d_colorlegend.cpp" />
+    <ClCompile Include="src\qwt3d_color_std.cpp" />
+    <ClCompile Include="src\qwt3d_coordsys.cpp" />
+    <ClCompile Include="src\qwt3d_data.cpp" />
+    <ClCompile Include="src\qwt3d_drawable.cpp" />
+    <ClCompile Include="src\qwt3d_enrichment_std.cpp" />
+    <ClCompile Include="src\qwt3d_extglwidget.cpp" />
+    <ClCompile Include="src\qwt3d_function.cpp" />
+    <ClCompile Include="src\qwt3d_graphplot.cpp" />
+    <ClCompile Include="src\qwt3d_gridmapping.cpp" />
+    <ClCompile Include="src\qwt3d_gridplot.cpp" />
+    <ClCompile Include="src\qwt3d_io.cpp" />
+    <ClCompile Include="src\qwt3d_io_reader.cpp" />
+    <ClCompile Include="src\qwt3d_label.cpp" />
+    <ClCompile Include="src\qwt3d_lighting.cpp" />
+    <ClCompile Include="src\qwt3d_meshplot.cpp" />
+    <ClCompile Include="src\qwt3d_parametricsurface.cpp" />
+    <ClCompile Include="src\qwt3d_plot3d.cpp" />
+    <ClCompile Include="src\qwt3d_scale.cpp" />
+    <ClCompile Include="src\qwt3d_surfaceplot.cpp" />
+    <ClCompile Include="src\qwt3d_types.cpp" />
+    <ClCompile Include="src\qwt3d_volumeplot.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\qwt3d_appearance.h" />
+    <ClInclude Include="include\qwt3d_autoscaler.h" />
+    <ClInclude Include="include\qwt3d_axis.h" />
+    <ClInclude Include="include\qwt3d_color.h" />
+    <ClInclude Include="include\qwt3d_colorlegend.h" />
+    <ClInclude Include="include\qwt3d_color_std.h" />
+    <ClInclude Include="include\qwt3d_coordsys.h" />
+    <ClInclude Include="include\qwt3d_data.h" />
+    <ClInclude Include="include\qwt3d_drawable.h" />
+    <ClInclude Include="include\qwt3d_enrichment.h" />
+    <ClInclude Include="include\qwt3d_enrichment_std.h" />
+    <CustomBuild Include="include\qwt3d_extglwidget.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+    </CustomBuild>
+    <ClInclude Include="include\qwt3d_function.h" />
+    <ClInclude Include="include\qwt3d_global.h" />
+    <ClInclude Include="include\qwt3d_graphplot.h" />
+    <ClInclude Include="include\qwt3d_gridmapping.h" />
+    <CustomBuild Include="include\qwt3d_gridplot.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+    </CustomBuild>
+    <ClInclude Include="include\qwt3d_helper.h" />
+    <ClInclude Include="include\qwt3d_io.h" />
+    <ClInclude Include="include\qwt3d_io_reader.h" />
+    <ClInclude Include="include\qwt3d_label.h" />
+    <ClInclude Include="include\qwt3d_mapping.h" />
+    <ClInclude Include="include\qwt3d_meshplot.h" />
+    <ClInclude Include="include\qwt3d_openglhelper.h" />
+    <ClInclude Include="include\qwt3d_parametricsurface.h" />
+    <CustomBuild Include="include\qwt3d_plot3d.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+    </CustomBuild>
+    <ClInclude Include="include\qwt3d_portability.h" />
+    <ClInclude Include="include\qwt3d_scale.h" />
+    <CustomBuild Include="include\qwt3d_surfaceplot.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(QT32)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT32)\include" "-I.\GeneratedFiles\." "-I$(QT32)\include\QtCore" "-I$(QT32)\include\QtGui" "-I$(QT32)\include\QtOpenGL" "-I$(QT32)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QT64)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\moc_%(Filename).cpp"  -DUNICODE -DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB  "-I.\GeneratedFiles" "-I." "-I$(QT64)\include" "-I.\GeneratedFiles\." "-I$(QT64)\include\QtCore" "-I$(QT64)\include\QtGui" "-I$(QT64)\include\QtOpenGL" "-I$(QT64)\include\QtWidgets" "-I.\..\..\..\include"</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\GeneratedFiles\moc_%(Filename).cpp</Outputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QT32)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QT64)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Filename)%(Extension)...</Message>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QT64)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+    </CustomBuild>
+    <ClInclude Include="include\qwt3d_types.h" />
+    <ClInclude Include="include\qwt3d_valueptr.h" />
+    <ClInclude Include="include\qwt3d_volumeplot.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{40CD35CA-3D02-446C-A457-5461316E0BD9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>qwtplot3dvc2015</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>qwtplot3d</TargetName>
+    <TargetExt>.lib</TargetExt>
+    <OutDir>..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\lib\</OutDir>
+    <IntDir>..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>qwtplot3d</TargetName>
+    <TargetExt>.lib</TargetExt>
+    <OutDir>..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\lib\</OutDir>
+    <IntDir>..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>qwtplot3d</TargetName>
+    <TargetExt>.lib</TargetExt>
+    <OutDir>..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\lib\</OutDir>
+    <IntDir>..\build-qwtplot3d-Desktop-Qt_VS2015_32bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>qwtplot3d</TargetName>
+    <TargetExt>.lib</TargetExt>
+    <OutDir>..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\lib\</OutDir>
+    <IntDir>..\build-qwtplot3d-Desktop-Qt_VS2015_64bit-$(Configuration)\tmp\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;QWT3D_DLL;QWT3D_MAKEDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\include;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(QT32)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;Qt5OpenGLd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;QWT3D_DLL;QWT3D_MAKEDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;$(QT64)\include;$(QT64)\include\QtCore;$(QT64)\include\QtGui;$(QT64)\include\QtOpenGL</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(QT64)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;Qt5OpenGLd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;QWT3D_DLL;QWT3D_MAKEDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;$(QT32)\include;$(QT32)\include\QtCore;$(QT32)\include\QtGui;$(QT32)\include\QtOpenGL</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(QT32)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5OpenGL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;QWT3D_DLL;QWT3D_MAKEDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;$(QT64)\include;$(QT64)\include\QtCore;$(QT64)\include\QtGui;$(QT64)\include\QtOpenGL</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(QT64)\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>glu32.lib;opengl32.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5OpenGL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/qwtplot3d-vc2015.vcxproj.filters
+++ b/qwtplot3d-vc2015.vcxproj.filters
@@ -1,0 +1,209 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="GeneratedFiles">
+      <UniqueIdentifier>{7550e37f-20fd-4ca3-96a0-ae09a4639da5}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\qwt3d_appearance.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_autoscaler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_axis.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_color_std.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_colorlegend.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_coordsys.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_data.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_drawable.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_enrichment_std.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_extglwidget.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_function.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_graphplot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_gridmapping.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_gridplot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_io.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_io_reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_label.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_lighting.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_meshplot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_parametricsurface.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_plot3d.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_scale.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_surfaceplot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_types.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\qwt3d_volumeplot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_extglwidget.cpp">
+      <Filter>GeneratedFiles</Filter>
+    </ClCompile>
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_gridplot.cpp">
+      <Filter>GeneratedFiles</Filter>
+    </ClCompile>
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_plot3d.cpp">
+      <Filter>GeneratedFiles</Filter>
+    </ClCompile>
+    <ClCompile Include="GeneratedFiles\moc_qwt3d_surfaceplot.cpp">
+      <Filter>GeneratedFiles</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\qwt3d_appearance.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_autoscaler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_axis.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_color.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_color_std.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_colorlegend.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_coordsys.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_data.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_drawable.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_enrichment.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_enrichment_std.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_function.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_global.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_graphplot.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_gridmapping.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_helper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_io_reader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_label.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_mapping.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_meshplot.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_openglhelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_parametricsurface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_portability.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_scale.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_valueptr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\qwt3d_volumeplot.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="include\qwt3d_extglwidget.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="include\qwt3d_gridplot.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="include\qwt3d_plot3d.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="include\qwt3d_surfaceplot.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
+</Project>

--- a/src/src.pro
+++ b/src/src.pro
@@ -18,13 +18,7 @@ HEADERS           += ../include/*.h
 INCLUDEPATH       = ../include
 
 win32 {
-  !build_pass {
-    win32-msvc | win32-msvc2002 {
-      error(Unsupported Visual Studio version ( < 2003 ))
-    }
-  }
-  
-  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 {
+  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 | win32-msvc2015 {
     QMAKE_CXXFLAGS += -MP
     QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
     QMAKE_CXXFLAGS_RELEASE += /fp:fast /arch:SSE2


### PR DESCRIPTION
I have made minor changes to the src.pro and common.pro files, to enable the library and the examples to be built using the MSVC 2015 compiler. Compilations on earlier versions of MSVC, and MinGW, should be unaffected.