### PR TITLE
Port to qopenglwidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 qwtplot3d
 =========
 
-Extended version of the original QwtPlot3D library
+Modified version of the original sintegrial/QwtPlot3D library to use QOpenGLWidget

--- a/config.pri
+++ b/config.pri
@@ -1,13 +1,7 @@
-CONFIG           += qt warn_on thread static
+CONFIG           += qt warn_on thread static release
 QT               += opengl
 
-win32 {
-  !build_pass {
-    win32-msvc | win32-msvc2002 {
-      error(Unsupported Visual Studio version ( < 2003 ))
-    }
-  }
-  
+win32 { 
   #win32-msvc2003 | win32-msvc2005 | win32-msvc2008 {
   #  TEMPLATE    = vclib
   #  CONFIG     += dll exceptions
@@ -22,14 +16,12 @@ win32 {
   #  }
   #}
 
-  win32-msvc2003 | win32-msvc2005 | win32-msvc2008 | win32-msvc2010 {
-    QMAKE_CXXFLAGS += -MP
-    QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
-    QMAKE_CXXFLAGS += -fp:fast -arch:SSE2
+  QMAKE_CXXFLAGS += -MP
+  QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
+  QMAKE_CXXFLAGS += -fp:fast -arch:SSE2
 
-    #test - asm output
-    QMAKE_CXXFLAGS += -FAs
-  }
+  #test - asm output
+  QMAKE_CXXFLAGS += -FAs
 }
 
 linux-g++:QMAKE_CXXFLAGS += -fno-exceptions

--- a/examples/autoswitch/autoswitch.cpp
+++ b/examples/autoswitch/autoswitch.cpp
@@ -25,20 +25,20 @@ Plot::Plot(QWidget* pw, int updateinterval)
 		coordinates()->axes[i].setMajors(7);
 		coordinates()->axes[i].setMinors(4);
 	}
-	
-	
+
+
 	coordinates()->axes[Qwt3D::X1].setLabelString("x");
 	coordinates()->axes[Y1].setLabelString("y");
-	coordinates()->axes[Z1].setLabelString("z"); 
+	coordinates()->axes[Z1].setLabelString("z");
 	coordinates()->axes[X2].setLabelString("x");
 	coordinates()->axes[Y2].setLabelString("y");
-	coordinates()->axes[Z2].setLabelString("z"); 
+	coordinates()->axes[Z2].setLabelString("z");
 	coordinates()->axes[X3].setLabelString("x");
 	coordinates()->axes[Y3].setLabelString("y");
-	coordinates()->axes[Z3].setLabelString("z"); 
+	coordinates()->axes[Z3].setLabelString("z");
 	coordinates()->axes[X4].setLabelString("x");
 	coordinates()->axes[Y4].setLabelString("y");
-	coordinates()->axes[Z4].setLabelString("z"); 
+	coordinates()->axes[Z4].setLabelString("z");
 
 
   QTimer* timer = new QTimer( this );
@@ -51,7 +51,7 @@ Plot::Plot(QWidget* pw, int updateinterval)
 void Plot::rotate()
 {
 	int prec = 3;
-		
+
 	setRotation(
 			(int(prec*xRotation() + 2) % (360*prec))/double(prec),
 			(int(prec*yRotation() + 2) % (360*prec))/double(prec),
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 		plot1->setBackgroundColor(RGBA(1,1, 157./255));
 		plot1->makeCurrent();
 		plot1->updateData();
-		plot1->updateGL();
+		plot1->update();
 
 
 		Plot* plot2 = new Plot(spl,80);
@@ -86,9 +86,9 @@ int main(int argc, char **argv)
 		plot2->setBackgroundColor(RGBA(1,1, 157./255));
 		plot2->makeCurrent();
 		plot2->updateData();
-		plot2->updateGL();
+		plot2->update();
 
     spl->resize(800,400);
     spl->show();
-    return a.exec(); 
+    return a.exec();
 }

--- a/examples/axes/src/axesmainwindow.cpp
+++ b/examples/axes/src/axesmainwindow.cpp
@@ -52,11 +52,11 @@ AxesMainWindow::AxesMainWindow( QWidget* parent)
 
 
 	rosenbrock = new Rosenbrock(*plot);
-	
+
 	rosenbrock->setMesh(31,33);
 	rosenbrock->setDomain(-1.73,1.8,-1.9,1.8);
 	rosenbrock->setMinZ(-100);
-	
+
 	rosenbrock->create();
 
 	for (unsigned i=0; i!=plot->coordinates()->axes.size(); ++i)
@@ -86,8 +86,8 @@ AxesMainWindow::AxesMainWindow( QWidget* parent)
 	plot->coordinates()->axes[X4].setLabelString("X4");
 	plot->coordinates()->axes[Y4].setLabelString("Y4");
 	plot->coordinates()->axes[Z4].setLabelString("Z4");
-  
-  
+
+
   plot->coordinates()->setLineSmooth(true);
   smoothBox->setDown(true);
 
@@ -97,12 +97,12 @@ AxesMainWindow::AxesMainWindow( QWidget* parent)
   Items->addAction( "&Letter", this, SLOT(letterItems()), QKeySequence("ALT+L") );
   Items->addAction( "&Time", this, SLOT(timeItems()), QKeySequence("ALT+T") );
   Items->addAction( "&Log", this, SLOT(customScale()), QKeySequence("ALT+C") );
-  
+
   plot->makeCurrent();
 	plot->updateData();
-  plot->updateGL();
+  plot->update();
 
-	connect(smoothBox, SIGNAL(toggled(bool)), this, SLOT(setSmoothLines(bool)) );	
+	connect(smoothBox, SIGNAL(toggled(bool)), this, SLOT(setSmoothLines(bool)) );
 	connect(numbergapslider, SIGNAL(valueChanged(int)), this, SLOT(setNumberGap(int)) );
 	connect(labelgapslider, SIGNAL(valueChanged(int)), this, SLOT(setLabelGap(int)) );
 	connect(ticLengthSlider, SIGNAL(valueChanged(int)), this, SLOT(setTicLength(int)) );
@@ -126,20 +126,20 @@ void AxesMainWindow::setNumberGap(int gap)
 {
 	plot->coordinates()->adjustNumbers(gap);
   plot->makeCurrent();
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::setLabelGap(int gap)
 {
 	plot->coordinates()->adjustLabels(gap);
   plot->makeCurrent();
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::setSmoothLines(bool val)
 {
   plot->coordinates()->setLineSmooth(val);
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::setTicLength(int val)
@@ -147,13 +147,13 @@ void AxesMainWindow::setTicLength(int val)
   double majl =  (plot->coordinates()->second()-plot->coordinates()->first()).length() / 1000.;
 	majl = majl * val;
 	plot->coordinates()->setTicLength(majl,0.6*majl);
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::setTicNumber(int degree)
 {
   plot->coordinates()->axes[X1].setMajors(tics + degree);
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::resetTics()
@@ -168,13 +168,13 @@ void AxesMainWindow::resetTics()
 }
 
 void AxesMainWindow::standardItems()
-{  
+{
   resetTics();
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::letterItems()
-{  
+{
   resetTics();
   ticNumberSlider->setEnabled(true);
   plot->coordinates()->axes[X1].setAutoScale(false);
@@ -188,31 +188,31 @@ void AxesMainWindow::letterItems()
   plot->coordinates()->axes[Y3].setScale(new Letter(false));
   plot->coordinates()->axes[Y4].setScale(new Letter(false));
 	plot->setTitle("Use the tics slider for this example!");
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::complexItems()
-{  
+{
   resetTics();
   plot->coordinates()->axes[Y1].setScale(new Imaginary);
   plot->coordinates()->axes[Y2].setScale(new Imaginary);
   plot->coordinates()->axes[Y3].setScale(new Imaginary);
   plot->coordinates()->axes[Y4].setScale(new Imaginary);
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::timeItems()
-{  
+{
   resetTics();
   plot->coordinates()->axes[Z1].setScale(new TimeItems);
   plot->coordinates()->axes[Z2].setScale(new TimeItems);
   plot->coordinates()->axes[Z3].setScale(new TimeItems);
   plot->coordinates()->axes[Z4].setScale(new TimeItems);
-  plot->updateGL();
+  plot->update();
 }
 
 void AxesMainWindow::customScale()
-{  
+{
   resetTics();
   plot->coordinates()->axes[Z1].setScale(LOG10SCALE);
   plot->coordinates()->axes[Z3].setScale(LOG10SCALE);
@@ -223,9 +223,9 @@ void AxesMainWindow::customScale()
 //  plot->coordinates()->axes[Z2].setAutoScale(false);
 //  plot->coordinates()->axes[Z3].setAutoScale(false);
 //  plot->coordinates()->axes[Z4].setAutoScale(false);
-  
+
   plot->coordinates()->setGridLines(true,true,Qwt3D::BACK);
 
-  plot->updateGL();
+  plot->update();
 }
 

--- a/examples/axes/src/main.cpp
+++ b/examples/axes/src/main.cpp
@@ -1,21 +1,23 @@
 /********************************************************************
     created:   2003/09/10
     filename:  main.cpp
-	
-    author:    Micha Bieber	
+
+    author:    Micha Bieber
 *********************************************************************/
 
 #include <qapplication.h>
 #include "axesmainwindow.h"
 
+#include <QGLFormat>
+
 
 int main( int argc, char** argv )
 {
 	QApplication app( argc, argv );
-	
-  if ( !QGLFormat::hasOpenGL() ) 
+
+  if ( !QGLFormat::hasOpenGL() )
 	{
-		qWarning( "This system has no OpenGL support. Exiting." );     
+		qWarning( "This system has no OpenGL support. Exiting." );
 		return -1;
   }
 

--- a/examples/common.pro
+++ b/examples/common.pro
@@ -1,5 +1,5 @@
 TEMPLATE     = app
-CONFIG      += qt warn_on thread
+CONFIG      += qt warn_on thread release
 QT += opengl
 UI_DIR = tmp
 MOC_DIR      = tmp
@@ -9,10 +9,8 @@ DEPENDPATH	= $$INCLUDEPATH
 DESTDIR = ../bin
 
 win32{
-  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 | win32-msvc2015 {
     QMAKE_CXXFLAGS += -MP
     QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
-  }
 
     LIBS += -L../../lib -lqwtplot3d -lopengl32 -lglu32 -lgdi32
 }

--- a/examples/dynamicplot/dynamicplot.cpp
+++ b/examples/dynamicplot/dynamicplot.cpp
@@ -90,7 +90,7 @@ void Plot::UpdateData()
     setTitle(QString("Dynamic Plotter Demonstration - Frame Time %1 ms").arg(rate));
 
     //updateData();
-	updateGL();
+	update();
 }
 
 int main(int argc, char **argv)

--- a/examples/enrichments/src/enrichmentmainwindow.cpp
+++ b/examples/enrichments/src/enrichmentmainwindow.cpp
@@ -19,7 +19,7 @@ public:
 	:Function(pw)
 	{
 	}
-	
+
 	double operator()(double x, double y)
 	{
     double ret = 1.0 / (x*x+y*y+0.5);
@@ -48,9 +48,9 @@ EnrichmentMainWindow::EnrichmentMainWindow( QWidget* parent )
   bar = (Bar*)plot->setPlotStyle(Bar(0.007,0.5));
 
   hat = new Hat(*plot);
-	
+
 	hat->setMesh(23,21);
-	hat->setDomain(-1.8,1.7,-1.6,1.7);	
+	hat->setDomain(-1.8,1.7,-1.6,1.7);
 
 	hat->create();
 
@@ -66,10 +66,10 @@ EnrichmentMainWindow::EnrichmentMainWindow( QWidget* parent )
 	plot->coordinates()->setLineWidth(1);
 	plot->coordinates()->setNumberFont("Courier",8);
   plot->coordinates()->adjustNumbers(5);
- 
+
 	setColor();
   plot->updateData();
-  plot->updateGL();
+  plot->update();
 
 
   levelSlider->setValue(50);
@@ -91,19 +91,19 @@ EnrichmentMainWindow::~EnrichmentMainWindow()
 
 
 void EnrichmentMainWindow::setColor()
-{	
+{
   Qwt3D::ColorVector cv;
-	
+
 	RGBA rgb;
 	int i = 252;
 	int step = 4;
 
   while (i>=0)
-  {    
+  {
     rgb.r = i/255.; rgb.g=(i-60>0) ? (i-60)/255.:0;rgb.b=0;
   //  rgb.a = 0.2;
-    cv.push_back(rgb);	
-    if (!--step) 
+    cv.push_back(rgb);
+    if (!--step)
     {
       i-=4;
       step=4;
@@ -111,7 +111,7 @@ void EnrichmentMainWindow::setColor()
   }
 	StandardColor col;
 	col.setColorVector(cv);
-	
+
 	plot->setDataColor(col);
 }
 
@@ -121,7 +121,7 @@ void EnrichmentMainWindow::setLevel(int i)
   level_ = 1 - i / 100.;
   bar->configure(width_,level_);
   plot->updateData();
-  plot->updateGL();
+  plot->update();
 }
 
 void EnrichmentMainWindow::setWidth(int i)
@@ -129,13 +129,13 @@ void EnrichmentMainWindow::setWidth(int i)
   width_ = i / 20000.;
   bar->configure(width_,level_);
   plot->updateData();
-  plot->updateGL();
+  plot->update();
 }
 
 void EnrichmentMainWindow::barSlot()
-{  
-  Bar b(width_,level_); 
+{
+  Bar b(width_,level_);
   bar = (Bar*)plot->setPlotStyle(b);
   plot->updateData();
-  plot->updateGL();
+  plot->update();
 }

--- a/examples/enrichments/src/main.cpp
+++ b/examples/enrichments/src/main.cpp
@@ -1,26 +1,28 @@
 /********************************************************************
     created:   2003/09/10
     filename:  main.cpp
-	
-    author:    Micha Bieber	
+
+    author:    Micha Bieber
 *********************************************************************/
 
 #include <qapplication.h>
 #include "enrichmentmainwindow.h"
 
+#include <QGLFormat>
+
 
 int main( int argc, char** argv )
 {
 	QApplication app( argc, argv );
-	
-  if ( !QGLFormat::hasOpenGL() ) 
+
+  if ( !QGLFormat::hasOpenGL() )
 	{
-		qWarning( "This system has no OpenGL support. Exiting." );     
+		qWarning( "This system has no OpenGL support. Exiting." );
 		return -1;
   }
 
 	EnrichmentMainWindow mainwindow;
-	
+
 	mainwindow.show();
 
 	return app.exec();

--- a/examples/graph/graph.cpp
+++ b/examples/graph/graph.cpp
@@ -1,6 +1,6 @@
   #include <qapplication.h>
   #include <qwt3d_graphplot.h>
-  
+
   using namespace Qwt3D;
 
   class Plot : public GraphPlot
@@ -36,12 +36,12 @@
     setCoordinateStyle(NOCOORD);
 
     updateData();
-    updateGL();
+    update();
   }
 
   void Plot::createCube(double length, const Triple& shift)
   {
-    
+
     unsigned m = nodes.size();
     nodes.push_back(Triple(0,0,0)+shift);
     nodes.push_back(Triple(0,0,length)+shift);
@@ -57,7 +57,7 @@
     edges.push_back(Edge(m+2, m+3));
     edges.push_back(Edge(m+3, m+0));
 
-    unsigned n = 4; 
+    unsigned n = 4;
 
     edges.push_back(Edge(m+0+n, m+1+n));
     edges.push_back(Edge(m+1+n, m+2+n));
@@ -69,13 +69,13 @@
     edges.push_back(Edge(m+2, m+2+n));
     edges.push_back(Edge(m+3, m+3+n));
   }
-  
+
   void Plot::createCubic1()
   {
     unsigned xs = 2;
     unsigned ys = xs;
     unsigned zs = xs;
-    double stretch = 1.3;      
+    double stretch = 1.3;
 
     unsigned i,j,k;
     for (i=0; i!=xs; ++i)
@@ -103,10 +103,10 @@
     for (i=0; i!=nodes.size()-1; ++i)
     {
       edges.push_back(Edge(i,i+1));
-    } 
+    }
     createDataset(nodes, edges);
   }
-  
+
   void Plot::createCubic3()
   {
     createCube(1, Triple(0,0,0));

--- a/examples/mesh/src/lightingdialog.cpp
+++ b/examples/mesh/src/lightingdialog.cpp
@@ -43,11 +43,11 @@ Plot::Plot(QWidget *parent)
 : GridPlot(parent)
 {
   setTitle("A Simple GridPlot Demonstration");
-  
+
   Sphere sphere(*this);
   sphere.create();
 
-  reset();  
+  reset();
   assignMouse(Qt::LeftButton,
     Qt::RightButton,
     Qt::LeftButton,
@@ -104,7 +104,7 @@ void Pointer::draw()
 	glGetIntegerv(GL_MATRIX_MODE, &mode);
 	glMatrixMode( GL_MODELVIEW );
   glPushMatrix();
-  
+
   glColor3d(1,0,0);
   glBegin(GL_LINES);
     glVertex3d(pos_.x, pos_.y, pos_.z);
@@ -123,7 +123,7 @@ LightingDlg::LightingDlg(QWidget *parent)
   QGridLayout *grid = new QGridLayout( frame);
 
   dataPlot = 0;
-  
+
   plot = new Plot(frame);
   plot->updateData();
 
@@ -148,54 +148,54 @@ void LightingDlg::setEmission(int val)
   if (!dataPlot)
     return;
   dataPlot->setMaterialComponent(GL_EMISSION, val / 100.);
-  dataPlot->updateGL();
+  dataPlot->update();
 }
 void LightingDlg::setDiff(int val)
 {
   if (!dataPlot)
     return;
   dataPlot->setLightComponent(GL_DIFFUSE, val / 100.);
-  dataPlot->updateGL();
+  dataPlot->update();
 }
 void LightingDlg::setSpec(int val)
 {
   if (!dataPlot)
     return;
   dataPlot->setMaterialComponent(GL_SPECULAR, val / 100.);
-  dataPlot->updateGL();
+  dataPlot->update();
 }
 void LightingDlg::setShin(int val)
 {
   if (!dataPlot)
     return;
   dataPlot->setShininess( val / 100.);
-  dataPlot->updateGL();
+  dataPlot->update();
 }
 
 void LightingDlg::reset()
 {
   plot->reset();
   if (dataPlot)
-    dataPlot->updateGL();
+    dataPlot->update();
 }
 
 void LightingDlg::setDistance(int val)
 {
-  
+
   plot->stick->setPos(0,0,val/100.);
   plot->updateData();
-  plot->updateGL();
-  
+  plot->update();
+
   double drad = (dataPlot->hull().maxVertex-dataPlot->hull().minVertex).length();
   drad *= val/20.;
 
   dataPlot->setLightShift(drad,drad,drad);
-  dataPlot->updateGL();
+  dataPlot->update();
 }
 
-void LightingDlg::assign(Qwt3D::Plot3D* pl) 
+void LightingDlg::assign(Qwt3D::Plot3D* pl)
 {
-  if (!pl) 
+  if (!pl)
     return;
   dataPlot = pl;
 }
@@ -204,8 +204,8 @@ void LightingDlg::setRotation(double x, double y, double z)
 {
   if (!dataPlot)
     return;
-  
+
   setDistance(distSL->value());
   dataPlot->setLightRotation(x,y,z);
-  dataPlot->updateGL();
+  dataPlot->update();
 }

--- a/examples/mesh/src/main.cpp
+++ b/examples/mesh/src/main.cpp
@@ -1,24 +1,26 @@
 /********************************************************************
     created:   2003/09/09
     filename:  main.cpp
-	
-    author:    Micha Bieber	
+
+    author:    Micha Bieber
 *********************************************************************/
 
 #include <qapplication.h>
 #include "meshmainwindow.h"
+
+#include <QGLFormat>
 
 int main( int argc, char **argv )
 {
   QApplication::setColorSpec( QApplication::CustomColor );
   QApplication app(argc,argv);
 
-  if ( !QGLFormat::hasOpenGL() ) 
+  if ( !QGLFormat::hasOpenGL() )
 	{
-		qWarning( "This system has no OpenGL support. Exiting." );     
+		qWarning( "This system has no OpenGL support. Exiting." );
 		return -1;
   }
-    
+
   MeshMainWindow mainwindow;
   mainwindow.resize(1024,768);
 	mainwindow.show();

--- a/examples/mesh/src/meshmainwindow.cpp
+++ b/examples/mesh/src/meshmainwindow.cpp
@@ -21,12 +21,12 @@ using namespace Qwt3D;
 using namespace std;
 
 
-MeshMainWindow::~MeshMainWindow()      
+MeshMainWindow::~MeshMainWindow()
 {
 	delete dataWidget;
 }
 
-MeshMainWindow::MeshMainWindow( QWidget* parent )       
+MeshMainWindow::MeshMainWindow( QWidget* parent )
 	: QMainWindow( parent )
 {
 	setupUi(this);
@@ -38,12 +38,12 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
   //coord->setExclusive(true);
 
   grids = new QActionGroup(this);
-  grids->addAction(front); 
+  grids->addAction(front);
   grids->addAction(back);
-  grids->addAction(right); 
+  grids->addAction(right);
   grids->addAction(left);
   grids->addAction(ceil);
-  grids->addAction(floor); 
+  grids->addAction(floor);
   grids->setExclusive(false);
 
   QActionGroup* plotstyle = new QActionGroup(this);
@@ -130,7 +130,7 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
 	connect( resetfont, SIGNAL( triggered() ), this, SLOT( resetFonts() ) );
 	connect( animation, SIGNAL( toggled(bool) ) , this, SLOT( toggleAnimation(bool) ) );
 	connect( openFile, SIGNAL( triggered() ) , this, SLOT( open() ) );
-	
+
   // only EXCLUSIVE groups emit selected :-/
   connect( left, SIGNAL( toggled( bool ) ), this, SLOT( setLeftGrid( bool ) ) );
 	connect( right, SIGNAL( toggled( bool ) ), this, SLOT( setRightGrid( bool ) ) );
@@ -145,18 +145,18 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
 	resSlider->setRange(1,70);
 	connect( resSlider, SIGNAL(valueChanged(int)), dataWidget, SLOT(setResolution(int)) );
 	connect( dataWidget, SIGNAL(resolutionChanged(int)), resSlider, SLOT(setValue(int)) );
-	resSlider->setValue(1);             
-	
+	resSlider->setValue(1);
+
 	connect( offsSlider, SIGNAL(valueChanged(int)), this, SLOT(setPolygonOffset(int)) );
 
-	connect(normButton, SIGNAL(clicked()), this, SLOT(setStandardView()));  
-	
+	connect(normButton, SIGNAL(clicked()), this, SLOT(setStandardView()));
+
   QString qwtstr(" qwtplot3d ");
   qwtstr += QString::number(QWT3D_MAJOR_VERSION) + ".";
   qwtstr += QString::number(QWT3D_MINOR_VERSION) + ".";
   qwtstr += QString::number(QWT3D_PATCH_VERSION) + " ";
 
-	QLabel* info = new QLabel(qwtstr, statusBar());       
+	QLabel* info = new QLabel(qwtstr, statusBar());
   statusBar()->addWidget(info, 0);
 	filenameWidget = new QLabel("                                  ", statusBar());
 	statusBar()->addWidget(filenameWidget,0);
@@ -170,7 +170,7 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
 	statusBar()->addWidget(scaleLabel,0);
 	zoomLabel = new QLabel("", statusBar());
 	statusBar()->addWidget(zoomLabel,0);
-	
+
 	connect(dataWidget, SIGNAL(rotationChanged(double,double,double)),this,SLOT(showRotate(double,double,double)));
 	connect(dataWidget, SIGNAL(vieportShiftChanged(double,double)),this,SLOT(showShift(double,double)));
 	connect(dataWidget, SIGNAL(scaleChanged(double,double,double)),this,SLOT(showScale(double,double,double)));
@@ -187,7 +187,7 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
 	connect(normals, SIGNAL( toggled(bool) ), this, SLOT( showNormals(bool)));
 	connect(normalsquality,  SIGNAL(valueChanged(int)), this, SLOT(setNormalQuality(int)) );
 	connect(normalslength,  SIGNAL(valueChanged(int)), this, SLOT(setNormalLength(int)) );
-			
+
 	setStandardView();
 
 	dataWidget->coordinates()->setLineSmooth(true);
@@ -196,7 +196,7 @@ MeshMainWindow::MeshMainWindow( QWidget* parent )
   dataWidget->setKeySpeed(15,20,20);
 
   lightingdlg_ = new LightingDlg( this );
-  lightingdlg_->assign( dataWidget);  
+  lightingdlg_->assign( dataWidget);
 
   dataWidget->setTitleFont( "Arial", 14, QFont::Normal );
 
@@ -213,31 +213,31 @@ void MeshMainWindow::open()
 
 	if ( s.isEmpty() || !dataWidget)
       return;
-	
+
   QFileInfo fi( s );
 	filenameWidget->setToolTip(s);
   QString ext = fi.suffix();
 	filenameWidget->setText(fi.fileName());
-    qApp->processEvents(); // enforces repaint;  
+    qApp->processEvents(); // enforces repaint;
 
   if (IO::load(dataWidget, s, ext))
 	{
 //		double a = dataWidget->facets().first;
 //		double b = dataWidget->facets().second;
 //
-//		dimWidget->setText(QString("Cells ") + QString::number(a*b) 
+//		dimWidget->setText(QString("Cells ") + QString::number(a*b)
 //			+ " (" + QString::number(a) + "x" + QString::number(b) +")" );
-		
+
 		dataWidget->setResolution(3);
 	}
- 	
+
 	for (unsigned i=0; i!=dataWidget->coordinates()->axes.size(); ++i)
 	{
 		dataWidget->coordinates()->axes[i].setMajors(4);
 		dataWidget->coordinates()->axes[i].setMinors(5);
 		dataWidget->coordinates()->axes[i].setLabelString("");
 	}
-	
+
 	updateColorLegend(4,5);
 	pickCoordSystem(activeCoordSystem);
 	dataWidget->showColorLegend(legend_);
@@ -246,7 +246,7 @@ void MeshMainWindow::open()
 void MeshMainWindow::createFunction(QString const& name)
 {
 	dataWidget->makeCurrent();
-  
+
   dataWidget->legend()->setScale(LINEARSCALE);
 	for (unsigned i=0; i!=dataWidget->coordinates()->axes.size(); ++i)
 	{
@@ -254,50 +254,50 @@ void MeshMainWindow::createFunction(QString const& name)
 		dataWidget->coordinates()->axes[i].setMinors(5);
 	}
 
-  if (name == QString("Rosenbrock")) 
+  if (name == QString("Rosenbrock"))
 	{
 		Rosenbrock rosenbrock(*dataWidget);
-		
+
 		rosenbrock.setMesh(50,51);
 		rosenbrock.setDomain(-1.73,1.55,-1.5,1.95);
 		rosenbrock.setMinZ(-100);
-		
+
 		rosenbrock.create();
-	  
+
     dataWidget->coordinates()->axes[Z1].setScale(LOG10SCALE);
     dataWidget->coordinates()->axes[Z2].setScale(LOG10SCALE);
     dataWidget->coordinates()->axes[Z3].setScale(LOG10SCALE);
     dataWidget->coordinates()->axes[Z4].setScale(LOG10SCALE);
     dataWidget->legend()->setScale(LOG10SCALE);
 	}
-	else if (name == QString("Hat")) 
+	else if (name == QString("Hat"))
 	{
 		Hat hat(*dataWidget);
-		
+
 		hat.setMesh(51,72);
 		hat.setDomain(-1.5,1.5,-1.5,1.5);
-		hat.create();	
+		hat.create();
 	}
-	else if (name == QString("Ripple")) 
+	else if (name == QString("Ripple"))
 	{
 		Ripple ripple(*dataWidget);
     ripple.setMesh(120,120);
-		ripple.create();	
+		ripple.create();
 	}
-	else if (name == QString("Saddle")) 
+	else if (name == QString("Saddle"))
 	{
 		Saddle saddle;
-		
+
 		saddle.setMesh(71,71);
 		double dom = 2.5;
 		saddle.setDomain(-dom, dom, -dom, dom);
 		saddle.assign(*dataWidget);
 		saddle.create();
 	}
-	else if (name == QString("Sombrero")) 
+	else if (name == QString("Sombrero"))
 	{
 		Mex mex;
-		
+
 		mex.setMesh(91,91);
 		double dom = 15;
 		mex.setDomain(-dom, dom, -dom, dom);
@@ -307,7 +307,7 @@ void MeshMainWindow::createFunction(QString const& name)
 //	double a = dataWidget->facets().first;
 //	double b = dataWidget->facets().second;
 //
-//	dimWidget->setText(QString("Cells ") + QString::number(a*b) 
+//	dimWidget->setText(QString("Cells ") + QString::number(a*b)
 //		+ " (" + QString::number(a) + "x" + QString::number(b) +")" );
 
 	updateColorLegend(7,5);
@@ -333,22 +333,22 @@ void MeshMainWindow::createFunction(QString const& name)
 void MeshMainWindow::createPSurface(QString const& name)
 {
 	dataWidget->makeCurrent();
-	if (name == QString("Torus")) 
+	if (name == QString("Torus"))
 	{
 		Torus sf(*dataWidget);
 		sf.create();
 	}
-	else if (name == QString("Seashell")) 
+	else if (name == QString("Seashell"))
 	{
 		Seashell ss(*dataWidget);
 		ss.create();
 	}
-	else if (name == QString("Boy")) 
+	else if (name == QString("Boy"))
 	{
 		Boy boy(*dataWidget);
 		boy.create();
 	}
-	else if (name == QString("Dini")) 
+	else if (name == QString("Dini"))
 	{
 		Dini dini(*dataWidget);
 		dini.create();
@@ -362,7 +362,7 @@ void MeshMainWindow::createPSurface(QString const& name)
 //	double a = dataWidget->facets().first;
 //	double b = dataWidget->facets().second;
 //
-//	dimWidget->setText(QString("Cells ") + QString::number(a*b) 
+//	dimWidget->setText(QString("Cells ") + QString::number(a*b)
 //		+ " (" + QString::number(a) + "x" + QString::number(b) +")" );
 
 	updateColorLegend(7,5);
@@ -392,7 +392,7 @@ void MeshMainWindow::pickCoordSystem( QAction* action)
 		return;
 
 	activeCoordSystem = action;
-	
+
 	dataWidget->setTitle("QwtPlot3D (Use Ctrl-Alt-Shift-LeftBtn-Wheel or keyboard)");
 
 	if (!dataWidget->hasData())
@@ -404,7 +404,7 @@ void MeshMainWindow::pickCoordSystem( QAction* action)
 			dataWidget->coordinates()->axes[i].setMajors(4);
 			dataWidget->coordinates()->axes[i].setMinors(5);
 		}
-	}			
+	}
 
 	if (action == Box || action == Frame)
 	{
@@ -452,7 +452,7 @@ void MeshMainWindow::pickPlotStyle( QAction* action )
 		dataWidget->setPlotStyle(NOPLOT);
 	}
 	dataWidget->updateData();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void
@@ -473,10 +473,10 @@ MeshMainWindow::pickFloorStyle( QAction* action )
 	{
 		dataWidget->setFloorStyle(NOFLOOR);
 	}
-	
+
 	dataWidget->updateData();
-	dataWidget->updateGL();
-}	
+	dataWidget->update();
+}
 
 void MeshMainWindow::setLeftGrid(bool b)
 {
@@ -507,7 +507,7 @@ void MeshMainWindow::setGrid(Qwt3D::SIDE s, bool b)
 {
   if (!dataWidget)
 		return;
-  
+
  int sum = dataWidget->coordinates()->grids();
 
   if (b)
@@ -516,7 +516,7 @@ void MeshMainWindow::setGrid(Qwt3D::SIDE s, bool b)
     sum &= ~s;
 
   dataWidget->coordinates()->setGridLines(sum!=Qwt3D::NOSIDEGRID, sum!=Qwt3D::NOSIDEGRID, sum);
-  dataWidget->updateGL();
+  dataWidget->update();
 }
 
 void MeshMainWindow::resetColors()
@@ -540,55 +540,55 @@ void MeshMainWindow::resetColors()
   dataWidget->setTitleColor(tc);
 
 	dataWidget->setDataColor(StandardColor());
-	dataWidget->updateData();	
+	dataWidget->updateData();
 	dataWidget->updateNormals();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 
 void MeshMainWindow::pickAxesColor()
 {
-  
+
   QColor c = QColorDialog::getColor( Qt::white, this );
   if ( !c.isValid() )
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->coordinates()->setAxesColor(rgb);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::pickBgColor()
 {
-  
+
 	QColor c = QColorDialog::getColor( Qt::white, this );
   if ( !c.isValid() )
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->setBackgroundColor(rgb);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::pickMeshColor()
 {
-  
+
 	QColor c = QColorDialog::getColor( Qt::white, this );
   if ( !c.isValid() )
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->setMeshColor(rgb);
 	dataWidget->updateData();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::pickNumberColor()
 {
-  
+
 	QColor c = QColorDialog::getColor( Qt::white, this );
   if ( !c.isValid() )
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->coordinates()->setNumberColor(rgb);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::pickLabelColor()
@@ -598,7 +598,7 @@ void MeshMainWindow::pickLabelColor()
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->coordinates()->setLabelColor(rgb);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 void MeshMainWindow::pickTitleColor()
 {
@@ -607,7 +607,7 @@ void MeshMainWindow::pickTitleColor()
 		return;
 	RGBA rgb = Qt2GL(c);
 	dataWidget->setTitleColor(rgb);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::pickLighting()
@@ -624,50 +624,50 @@ void MeshMainWindow::pickDataColor()
 void MeshMainWindow::adaptDataColors(const QString& fileName)
 {
   ColorVector cv;
-	
+
 	if (!openColorMap(cv, fileName))
 		return;
-	
+
 	StandardColor col_;
 	col_.setColorVector(cv);
-	
+
 	dataWidget->setDataColor(col_);
 	dataWidget->updateData();
 	dataWidget->updateNormals();
 	dataWidget->showColorLegend(legend_);
-  dataWidget->updateGL();
+  dataWidget->update();
 }
 
 void MeshMainWindow::pickNumberFont()
 {
 	bool ok;
 	QFont font = QFontDialog::getFont(&ok, this );
-	if ( !ok ) 
+	if ( !ok )
 	{
 		return;
-	} 
+	}
 	dataWidget->coordinates()->setNumberFont(font);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 void MeshMainWindow::pickLabelFont()
 {
 	bool ok;
 	QFont font = QFontDialog::getFont(&ok, this );
-	if ( !ok ) 
+	if ( !ok )
 	{
 		return;
-	} 
+	}
 	dataWidget->coordinates()->setLabelFont(font);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 void MeshMainWindow::pickTitleFont()
 {
 	bool ok;
 	QFont font = QFontDialog::getFont(&ok, this );
-	if ( !ok ) 
+	if ( !ok )
 	{
 		return;
-	} 
+	}
 	dataWidget->setTitleFont(font.family(), font.pointSize(), font.weight(), font.italic());
 }
 
@@ -676,7 +676,7 @@ void MeshMainWindow::resetFonts()
 	dataWidget->coordinates()->setNumberFont(QFont("Courier", 12));
 	dataWidget->coordinates()->setLabelFont(QFont("Courier", 14, QFont::Bold));
   dataWidget->setTitleFont( "Arial", 14, QFont::Normal );
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MeshMainWindow::setStandardView()
@@ -731,7 +731,7 @@ void
 MeshMainWindow::toggleAutoScale(bool val)
 {
 	dataWidget->coordinates()->setAutoScale(val);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void
@@ -748,34 +748,34 @@ MeshMainWindow::setPolygonOffset(int val)
 {
 	dataWidget->setPolygonOffset(val / 10.0);
 	dataWidget->updateData();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void
-MeshMainWindow::showRotate(double x, double y, double z)		
+MeshMainWindow::showRotate(double x, double y, double z)
 {
-	rotateLabel->setText(" Angles ("  + QString::number(x,'g',3) + " ," 
+	rotateLabel->setText(" Angles ("  + QString::number(x,'g',3) + " ,"
 																	+ QString::number(y,'g',3) + " ,"
 																	+ QString::number(z,'g',3) + ")");
 }
 void
-MeshMainWindow::showShift(double x, double y)		
+MeshMainWindow::showShift(double x, double y)
 {
-	shiftLabel->setText(" Shifts (" + QString::number(x,'g',3) + " ," 
+	shiftLabel->setText(" Shifts (" + QString::number(x,'g',3) + " ,"
 																	+ QString::number(y,'g',3) + " )"
 																	);
 }
 void
-MeshMainWindow::showScale(double x, double y, double z)		
+MeshMainWindow::showScale(double x, double y, double z)
 {
-	scaleLabel->setText(" Scales (" + QString::number(x,'g',3) + " ," 
+	scaleLabel->setText(" Scales (" + QString::number(x,'g',3) + " ,"
 																	+ QString::number(y,'g',3) + " ,"
 																	+ QString::number(z,'g',3) + ")");
 }
 void
-MeshMainWindow::showZoom(double z)		
+MeshMainWindow::showZoom(double z)
 {
-	zoomLabel->setText(" Zoom "  + QString::number(z,'g',3)); 
+	zoomLabel->setText(" Zoom "  + QString::number(z,'g',3));
 }
 
 void
@@ -783,7 +783,7 @@ MeshMainWindow::showNormals(bool val)
 {
 	dataWidget->showNormals(val);
 	dataWidget->updateNormals();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void
@@ -791,7 +791,7 @@ MeshMainWindow::setNormalLength(int val)
 {
 	dataWidget->setNormalLength(val / 400.);
 	dataWidget->updateNormals();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void
@@ -799,25 +799,25 @@ MeshMainWindow::setNormalQuality(int val)
 {
 	dataWidget->setNormalQuality(val);
 	dataWidget->updateNormals();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 bool
 MeshMainWindow::openColorMap(ColorVector& cv, QString fname)
-{	
+{
   if (fname.isEmpty())
     return false;
-  
+
   ifstream file(QWT3DLOCAL8BIT(fname));
 
 	if (!file)
 		return false;
-	
+
 	RGBA rgb;
 	cv.clear();
-	
-	while ( file ) 
-	{		
+
+	while ( file )
+	{
 		file >> rgb.r >> rgb.g >> rgb.b;
 		file.ignore(1000,'\n');
 		if (!file.good())
@@ -828,14 +828,14 @@ MeshMainWindow::openColorMap(ColorVector& cv, QString fname)
 			rgb.r /= 255;
 			rgb.g /= 255;
 			rgb.b /= 255;
-			cv.push_back(rgb);	
+			cv.push_back(rgb);
 		}
 	}
 
 	return true;
 }
 
-void 
+void
 MeshMainWindow::updateColorLegend(int majors, int minors)
 {
 	dataWidget->legend()->setMajors(majors);
@@ -843,11 +843,11 @@ MeshMainWindow::updateColorLegend(int majors, int minors)
 	double start, stop;
 	dataWidget->coordinates()->axes[Z1].limits(start,stop);
 	dataWidget->legend()->setLimits(start, stop);
-}		
+}
 
 void MeshMainWindow::enableLighting(bool val)
 {
   dataWidget->enableLighting(val);
   dataWidget->illuminate(0);
-  dataWidget->updateGL();
+  dataWidget->update();
 }

--- a/examples/plotlets/src/main.cpp
+++ b/examples/plotlets/src/main.cpp
@@ -1,24 +1,26 @@
 /********************************************************************
     created:   2003/09/09
     filename:  main.cpp
-	
-    author:    Micha Bieber	
+
+    author:    Micha Bieber
 *********************************************************************/
 
 #include <qapplication.h>
 #include "mainwindow.h"
+
+#include <QGLFormat>
 
 int main( int argc, char **argv )
 {
   QApplication::setColorSpec( QApplication::CustomColor );
   QApplication app(argc,argv);
 
-  if ( !QGLFormat::hasOpenGL() ) 
+  if ( !QGLFormat::hasOpenGL() )
 	{
-		qWarning( "This system has no OpenGL support. Exiting." );     
+		qWarning( "This system has no OpenGL support. Exiting." );
 		return -1;
   }
-    
+
   MainWindow mainwindow;
   mainwindow.resize(1024,768);
 	mainwindow.show();

--- a/examples/plotlets/src/mainwindow.cpp
+++ b/examples/plotlets/src/mainwindow.cpp
@@ -12,7 +12,7 @@
 #include <qtoolbar.h>
 #include <qimage.h>
 #include <qpixmap.h>
-#include <qfiledialog.h>       
+#include <qfiledialog.h>
 #include <qstatusbar.h>
 #include <qfileinfo.h>
 #include <qslider.h>
@@ -36,12 +36,12 @@ using namespace Qwt3D;
 using namespace std;
 
 
-MainWindow::~MainWindow()      
+MainWindow::~MainWindow()
 {
 	delete dataWidget;
 }
 
-MainWindow::MainWindow( QWidget* parent )       
+MainWindow::MainWindow( QWidget* parent )
 	: QMainWindow( parent )
 {
 	setupUi(this);
@@ -78,7 +78,7 @@ MainWindow::MainWindow( QWidget* parent )
 
 
  PM_IT i = pmanager.begin();
- while (i != pmanager.end()) 
+ while (i != pmanager.end())
  {
    connect( i->cbox, SIGNAL( toggled( bool ) ), this, SLOT( togglePlotlet( bool ) ) );
    connect(i->cfgframe, SIGNAL(meshColorChanged()), this, SLOT(setMeshColor()));
@@ -93,11 +93,11 @@ MainWindow::MainWindow( QWidget* parent )
 	//resSlider->setRange(1,70);
 	//connect( resSlider, SIGNAL(valueChanged(int)), dataWidget, SLOT(setResolution(int)) );
 	//connect( dataWidget, SIGNAL(resolutionChanged(int)), resSlider, SLOT(setValue(int)) );
-	//resSlider->setValue(1);             
+	//resSlider->setValue(1);
 	//
 	//connect( offsSlider, SIGNAL(valueChanged(int)), this, SLOT(setPolygonOffset(int)) );
 
-	connect(normButton, SIGNAL(clicked()), this, SLOT(setStandardView()));  
+	connect(normButton, SIGNAL(clicked()), this, SLOT(setStandardView()));
 	//
  // QString qwtstr(" qwtplot3d ");
  // qwtstr += QString::number(QWT3D_MAJOR_VERSION) + ".";
@@ -108,7 +108,7 @@ MainWindow::MainWindow( QWidget* parent )
 	//connect(colorlegend, SIGNAL( toggled(bool) ), this, SLOT( toggleColorLegend(bool)));
 	connect(autoscale, SIGNAL( toggled(bool) ), this, SLOT( toggleAutoScale(bool)));
 	//connect(normals, SIGNAL( toggled(bool) ), this, SLOT( showNormals(bool)));
-	//		
+	//
 	setStandardView();
 
 	dataWidget->coordinates()->setLineSmooth(true);
@@ -145,29 +145,29 @@ MainWindow::MainWindow( QWidget* parent )
 int MainWindow::createFunction(QString const& name, bool append /*= true*/)
 {
 	dataWidget->makeCurrent();
-  if (name == QString("hat")) 
+  if (name == QString("hat"))
   {
     Hat hat(*dataWidget, true);
 
     hat.setMesh(51,72);
     hat.setDomain(-1.5,1.5,-1.5,1.5);
-    hat.create(append);	
+    hat.create(append);
   }
-  else if (name == QString("hatn")) 
+  else if (name == QString("hatn"))
   {
     Hat hat(*dataWidget, false);
 
     hat.setMesh(51,72);
     hat.setDomain(-1.5,1.5,-1.5,1.5);
-    hat.create(append);	
+    hat.create(append);
   }
-	else if (name == QString("ripple")) 
+	else if (name == QString("ripple"))
 	{
 		Ripple ripple(*dataWidget);
     ripple.setMesh(120,120);
-		ripple.create(append);	
+		ripple.create(append);
 	}
-  else if (name == QString("boy")) 
+  else if (name == QString("boy"))
   {
     Boy boy(*dataWidget);
     boy.create(append);
@@ -177,7 +177,7 @@ int MainWindow::createFunction(QString const& name, bool append /*= true*/)
 
   if (append)
     return (int)(dataWidget->plotlets() - 1);
-  
+
   return 0;
 }
 
@@ -189,7 +189,7 @@ void MainWindow::setPlotStyle()
     return;
   dataWidget->appearance(pos).setPlotStyle(w->plotstyle());
   dataWidget->updateData();
-  dataWidget->updateGL();
+  dataWidget->update();
 }
 
 void MainWindow::pickFloorStyle( QAction* /*action*/ )
@@ -211,8 +211,8 @@ void MainWindow::pickFloorStyle( QAction* /*action*/ )
 	//}
 	//
 	//dataWidget->updateData();
-	//dataWidget->updateGL();
-}	
+	//dataWidget->update();
+}
 
 void MainWindow::setMeshColor()
 {
@@ -222,7 +222,7 @@ void MainWindow::setMeshColor()
     return;
 	dataWidget->appearance(pos).setMeshColor(w->meshColor());
 	dataWidget->updateData();
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MainWindow::setDataColor()
@@ -235,7 +235,7 @@ void MainWindow::setDataColor()
   dataWidget->updateData();
   dataWidget->updateNormals();
   //dataWidget->showColorLegend(legend_);
-  dataWidget->updateGL();
+  dataWidget->update();
 }
 
 void MainWindow::setStandardView()
@@ -260,28 +260,28 @@ void MainWindow::toggleColorLegend(bool /*val*/)
 void MainWindow::toggleAutoScale(bool val)
 {
 	dataWidget->coordinates()->setAutoScale(val);
-	dataWidget->updateGL();
+	dataWidget->update();
 }
 
 void MainWindow::showNormals(bool /*val*/)
 {
 	//dataWidget->showNormals(val);
 	//dataWidget->updateNormals();
-	//dataWidget->updateGL();
+	//dataWidget->update();
 }
 
 void MainWindow::setNormalLength(int /*val*/)
 {
 	//dataWidget->setNormalLength(val / 400.);
 	//dataWidget->updateNormals();
-	//dataWidget->updateGL();
+	//dataWidget->update();
 }
 
 void MainWindow::setNormalQuality(int /*val*/)
 {
 	//dataWidget->setNormalQuality(val);
 	//dataWidget->updateNormals();
-	//dataWidget->updateGL();
+	//dataWidget->update();
 }
 
 void MainWindow::updateColorLegend(int /*majors*/, int /*minors*/)
@@ -291,7 +291,7 @@ void MainWindow::updateColorLegend(int /*majors*/, int /*minors*/)
 	//double start, stop;
 	//dataWidget->coordinates()->axes[Z1].limits(start,stop);
 	//dataWidget->legend()->setLimits(start, stop);
-}		
+}
 
 void MainWindow::togglePlotlet(bool val)
 {
@@ -301,13 +301,13 @@ void MainWindow::togglePlotlet(bool val)
     if (2 == dataWidget->plotlets()) // we are going to remove the penultimate plotlet...
     {
       // ... so make sure, the last one will be secured
-      while (i != pmanager.end()) 
+      while (i != pmanager.end())
       {
         if (i->cbox->isChecked() && i->cbox != sender())
         {
           i->cbox->setEnabled(false);
           break;
-        }       
+        }
         ++i;
       }
     }
@@ -315,7 +315,7 @@ void MainWindow::togglePlotlet(bool val)
     // ... remove the plotlet
     int deleted = -1;
     i = pmanager.begin();
-    while (i != pmanager.end()) 
+    while (i != pmanager.end())
     {
       if (sender() == i->cbox)
       {
@@ -326,17 +326,17 @@ void MainWindow::togglePlotlet(bool val)
       }
       ++i;
     }
-    
+
     // ... recalculate indexes
     if (deleted>=0)
     {
       i = pmanager.begin();
-      while (i != pmanager.end()) 
+      while (i != pmanager.end())
       {
         if (i->pos >= deleted)
         {
           --i->pos; // cannot be < 1 prior to decr.
-        }      
+        }
         ++i;
       }
     }
@@ -344,7 +344,7 @@ void MainWindow::togglePlotlet(bool val)
   else // adding plotlets
   {
     PM_IT i = pmanager.begin();
-    while (i != pmanager.end()) 
+    while (i != pmanager.end())
     {
       // re-enable possible single plotlet checkbox
       if (!i->cbox->isEnabled())
@@ -357,20 +357,20 @@ void MainWindow::togglePlotlet(bool val)
           dataWidget->appearance(i->pos).setMeshColor(i->cfgframe->meshColor());
           dataWidget->appearance(i->pos).setDataColor(i->cfgframe->dataColor());
           dataWidget->appearance(i->pos).setPlotStyle(i->cfgframe->plotstyle());
-          dataWidget->updateData();	
+          dataWidget->updateData();
           dataWidget->updateNormals();
        }
       }
       ++i;
     }
   }
-  dataWidget->updateGL();
+  dataWidget->update();
 }
 
 int MainWindow::findPlotletPosition( const ConfigFrame* val ) const
 {
   PM_CIT i = pmanager.begin();
-  while (i != pmanager.end()) 
+  while (i != pmanager.end())
   {
     if (i->cfgframe == val)
       return i->pos;

--- a/examples/simpleplot/simpleplot.cpp
+++ b/examples/simpleplot/simpleplot.cpp
@@ -8,7 +8,7 @@
   #include <qapplication.h>
   #include <qwt3d_gridplot.h>
   #include <qwt3d_function.h>
-  
+
 
   using namespace Qwt3D;
 
@@ -38,7 +38,7 @@
   Plot::Plot()
   {
     setTitle("A Simple GridPlot Demonstration");
-    
+
     Rosenbrock rosenbrock(*this);
 
     rosenbrock.setMesh(100,100);    // 200000 polys
@@ -67,7 +67,7 @@
     setCoordinateStyle(BOX);
 
     updateData();
-    updateGL();
+    update();
   }
 
   int main(int argc, char **argv)

--- a/examples/volumeplot/volumeplot.cpp
+++ b/examples/volumeplot/volumeplot.cpp
@@ -95,7 +95,7 @@ Plot::Plot(): VolumePlot()
     setCoordinateStyle(FRAME);
 
     updateData();
-    updateGL();
+    update();
 }
 
 int main(int argc, char **argv)

--- a/include/qwt3d_axis.h
+++ b/include/qwt3d_axis.h
@@ -10,7 +10,7 @@
 namespace Qwt3D
 {
 
-//! Autoscalable axis with caption. 
+//! Autoscalable axis with caption.
 /*!
   Axes are highly customizable especially in terms
   of labeling and scaling.
@@ -23,20 +23,20 @@ public:
   Axis(); //!< Constructs standard axis
   Axis(Qwt3D::Triple beg, Qwt3D::Triple end); //!< Constructs a new axis with specified limits
   virtual ~Axis(); // dtor
-  
+
   virtual void draw(); //!< Draws axis
 
-  /** 
+  /**
   Used to tag the axis as a z-axis. This information is used to draw correct labels.
   The standard value for axes is false;
   */
-  void setZ(bool val) {isZ_=val;} 
+  void setZ(bool val) {isZ_=val;}
   bool isZ() const {return isZ_;} //!< Is a z-axis
 
   void setPosition(const Qwt3D::Triple& beg, const Qwt3D::Triple& end); //!< Positionate axis
   void position(Qwt3D::Triple& beg, Qwt3D::Triple& end) const {beg = beg_; end = end_;} //!< Returns axis' position
   Qwt3D::Triple begin() const { return beg_; } //!< Returns axis' beginning position
-  Qwt3D::Triple end() const { return end_; } //!< Returns axis' ending position 
+  Qwt3D::Triple end() const { return end_; } //!< Returns axis' ending position
   double length() const { return (end_-beg_).length(); } //!< Returns axis' length
 
   void setTicLength(double majorl, double minorl); //!< Sets tics lengths in world coordinates
@@ -45,13 +45,13 @@ public:
   void setTicOrientation(double tx, double ty, double tz); //!< Sets tic orientation
   void setTicOrientation(const Qwt3D::Triple& val); //!< Same function as above
   Qwt3D::Triple ticOrientation() const { return orientation_;} //!< Returns tic orientation
-  void setSymmetricTics( bool b) { symtics_ = b;} //!< Sets two-sided tics (default is false) 
-    
+  void setSymmetricTics( bool b) { symtics_ = b;} //!< Sets two-sided tics (default is false)
+
   //! Sets font for axis label
   void setLabelFont(QString const& family, int pointSize, int weight = QFont::Normal, bool italic = false);
   void setLabelFont(QFont const& font); //!< Sets font for axis label
-  QFont const& labelFont() const {return labelfont_;} //!< Returns current label font 
-  
+  QFont const& labelFont() const {return labelfont_;} //!< Returns current label font
+
   void setLabelString(QString const& name);   //!< Sets label content
   void setLabelPosition(const Qwt3D::Triple& pos, Qwt3D::ANCHOR);
   void setLabelColor(Qwt3D::RGBA col);
@@ -82,7 +82,7 @@ public:
   int minors() const { return minorintervals_; } //!< Returns number of minor intervals
   Qwt3D::TripleVector const& majorPositions() const {return majorpos_;} //!< Returns positions for actual major tics (also if invisible)
   Qwt3D::TripleVector const& minorPositions() const {return minorpos_;} //!< Returns positions for actual minor tics (also if invisible)
-  
+
   //! Sets line width for axis components
   void setLineWidth(double val, double majfac = 0.9, double minfac = 0.5);
   double lineWidth() const { return lineWidth_;} //!< Returns line width for axis body
@@ -90,7 +90,7 @@ public:
   double minLineWidth() const { return minLineWidth_;} //!< Returns Line width for minor tics
 
   void setLimits(double start, double stop) {start_=start; stop_=stop;} //!< Sets interval
-  void limits(double& start, double& stop) const {start = start_; stop = stop_;} //!< Returns axis interval
+  void limits(double& start, double& stop) const; //!< Returns axis interval
   void recalculateTics(); //!< Enforces recalculation of ticmark positions
 
 
@@ -105,8 +105,8 @@ private:
   bool prepTicCalculation(Triple& startpoint);
 
   Qwt3D::Triple biggestNumberString();
-  
-  
+
+
   Qwt3D::ANCHOR scaleNumberAnchor_;
   Qwt3D::Label label_;
   std::vector<Qwt3D::Label> markerLabel_;
@@ -129,13 +129,13 @@ private:
   QFont numberfont_, labelfont_;
   Qwt3D::RGBA  numbercolor_;
 
-  int numbergap_, labelgap_; 
+  int numbergap_, labelgap_;
 
   Qwt3D::ValuePtr<Qwt3D::Scale> scale_;
 
   bool isZ_; // identify z-axis
 };
 
-} // ns 
+} // ns
 
 #endif /* include guard */

--- a/include/qwt3d_color.h
+++ b/include/qwt3d_color.h
@@ -13,7 +13,7 @@ class Plot3D;
 //! Abstract base class for color functors
 /*!
 Use your own color model by providing an implementation of operator()(double x, double y, double z).
-Colors destructor has been declared \c protected, in order to use only heap based objects. Plot3D 
+Colors destructor has been declared \c protected, in order to use only heap based objects. Plot3D
 will handle the objects destruction.
 See StandardColor for an example
 */
@@ -23,19 +23,19 @@ public:
   virtual ~Color(){}
   virtual Color* clone() const = 0;
   virtual Qwt3D::RGBA rgba(double x, double y, double z) const = 0; //!< Implement your color model here
-  virtual Qwt3D::RGBA rgba(Qwt3D::Triple const& t) const {return this->rgba(t.x,t.y,t.z);} 
+  virtual Qwt3D::RGBA rgba(Qwt3D::Triple const& t) const {return this->rgba(t.x,t.y,t.z);}
   //! Should create a color vector usable by ColorLegend. The default implementation returns vec
   virtual Qwt3D::ColorVector& createVector(Qwt3D::ColorVector& vec) { return vec; }
   //! Called from Appearance::update(). The default implementation is empty.
-  virtual void update(const Plot3D&) {} 
+  virtual void update(const Plot3D&) {}
 };
 
 //template<>
-//struct ValuePtrTraits<Color>  
+//struct ValuePtrTraits<Color>
 //{
-//  static  Color* clone( const Color* p )  
-//  { 
-//    return p->clone(); 
+//  static  Color* clone( const Color* p )
+//  {
+//    return p->clone();
 //  }
 //};
 

--- a/include/qwt3d_extglwidget.h
+++ b/include/qwt3d_extglwidget.h
@@ -10,22 +10,22 @@ class QKeyEvent;
 
 namespace Qwt3D
 {
-  
+
 //! An enhanced QGLWidget
 /*!
   The class covers mouse/keyboard handling, lighting and basic transformations, like
   scaling, shifting and rotating objects.
 */
-class QWT3D_EXPORT ExtGLWidget : public QGLWidget
+class QWT3D_EXPORT ExtGLWidget : public QOpenGLWidget
 {
   Q_OBJECT
 
 public:
-  ExtGLWidget ( QWidget * parent = 0, const QGLWidget * shareWidget = 0 );
+  ExtGLWidget ( QWidget * parent = 0 );
   virtual ~ExtGLWidget() {}
-	
+
   // transformations
-  
+
 	double xRotation() const { return xRot_;}  //!< Returns rotation around X axis [-360..360] (some angles are equivalent)
 	double yRotation() const { return yRot_;}  //!< Returns rotation around Y axis [-360..360] (some angles are equivalent)
 	double zRotation() const { return zRot_;}  //!< Returns rotation around Z axis [-360..360] (some angles are equivalent)
@@ -33,10 +33,10 @@ public:
 	double xShift() const { return xShift_;} //!< Returns shift along X axis (object coordinates)
 	double yShift() const { return yShift_;} //!< Returns shift along Y axis (object coordinates)
 	double zShift() const { return zShift_;} //!< Returns shift along Z axis (object coordinates)
-	
+
 	double xViewportShift() const { return xVPShift_;} //!< Returns relative shift [-1..1] along X axis (view coordinates)
 	double yViewportShift() const { return yVPShift_;} //!< Returns relative shift [-1..1] along Y axis (view coordinates)
-	
+
 	double xScale() const { return xScale_;} //!< Returns scaling for X values [0..inf]
 	double yScale() const { return yScale_;} //!< Returns scaling for Y values [0..inf]
 	double zScale() const { return zScale_;} //!< Returns scaling for Z values [0..inf]
@@ -44,33 +44,33 @@ public:
 	double zoom() const { return zoom_;} //!< Returns zoom (0..inf)
 	bool ortho() const { return ortho_; } //!< Returns orthogonal (true) or perspective (false) projection
 
-	
+
   // input devices
 
 	void assignMouse(MouseState xrot, MouseState yrot, MouseState zrot,
 									 MouseState xscale, MouseState yscale, MouseState zscale,
 									 MouseState zoom, MouseState xshift, MouseState yshift);
-	
+
 	bool mouseEnabled() const; //!< Returns true, if the widget accept mouse input from the user
 	void assignKeyboard(
      KeyboardState xrot_n, KeyboardState xrot_p
     ,KeyboardState yrot_n, KeyboardState yrot_p
     ,KeyboardState zrot_n, KeyboardState zrot_p
-		,KeyboardState xscale_n, KeyboardState xscale_p 
+		,KeyboardState xscale_n, KeyboardState xscale_p
     ,KeyboardState yscale_n, KeyboardState yscale_p
     ,KeyboardState zscale_n, KeyboardState zscale_p
 		,KeyboardState zoom_n, KeyboardState zoom_p
     ,KeyboardState xshift_n, KeyboardState xshift_p
     ,KeyboardState yshift_n, KeyboardState yshift_p
     );
-	
+
 	bool keyboardEnabled() const; //!< Returns true, if the widget accept keyboard input from the user
   //! Sets speed for keyboard driven transformations
-  void setKeySpeed(double rot, double scale, double shift); 
+  void setKeySpeed(double rot, double scale, double shift);
   //! Gets speed for keyboard driven transformations
-  void keySpeed(double& rot, double& scale, double& shift) const; 
- 
-  
+  void keySpeed(double& rot, double& scale, double& shift) const;
+
+
   // lighting
 
   bool lightingEnabled() const; //!< Returns true, if Lighting is enabled, false else
@@ -79,11 +79,11 @@ public:
   //! Turn light off
   void blowout(unsigned light = 0);
 
-  void setMaterialComponent(GLenum property, double r, double g, double b, double a = 1.0);    
-  void setMaterialComponent(GLenum property, double intensity);    
+  void setMaterialComponent(GLenum property, double r, double g, double b, double a = 1.0);
+  void setMaterialComponent(GLenum property, double intensity);
   void setShininess(double exponent);
-  void setLightComponent(GLenum property, double r, double g, double b, double a = 1.0, unsigned light=0);    
-  void setLightComponent(GLenum property, double intensity, unsigned light=0);    
+  void setLightComponent(GLenum property, double r, double g, double b, double a = 1.0, unsigned light=0);
+  void setLightComponent(GLenum property, double intensity, unsigned light=0);
   //! Returns Light 'idx' rotation around X axis [-360..360] (some angles are equivalent)
   double xLightRotation(unsigned idx = 0) const { return (idx<8) ? lights_[idx].rot.x : 0;}
   //! Returns Light 'idx' rotation around Y axis [-360..360] (some angles are equivalent)
@@ -91,16 +91,16 @@ public:
   //! Returns Light 'idx' rotation around Z axis [-360..360] (some angles are equivalent)
   double zLightRotation(unsigned idx = 0) const { return (idx<8) ? lights_[idx].rot.z : 0;}
   //! Returns shift of Light 'idx 'along X axis (object coordinates)
-  double xLightShift(unsigned idx = 0) const {return (idx<8) ? lights_[idx].shift.x : 0;} 
+  double xLightShift(unsigned idx = 0) const {return (idx<8) ? lights_[idx].shift.x : 0;}
   //! Returns shift of Light 'idx 'along Y axis (object coordinates)
-  double yLightShift(unsigned idx = 0) const {return (idx<8) ? lights_[idx].shift.y : 0;} 
+  double yLightShift(unsigned idx = 0) const {return (idx<8) ? lights_[idx].shift.y : 0;}
   //! Returns shift of Light 'idx 'along Z axis (object coordinates)
   double zLightShift(unsigned idx = 0) const {return (idx<8) ? lights_[idx].shift.z : 0;}
-  
+
 
 signals:
 	//! Emitted, if the rotation is changed
-  void rotationChanged( double xAngle, double yAngle, double zAngle ); 
+  void rotationChanged( double xAngle, double yAngle, double zAngle );
 	//! Emitted, if the shift is changed
 	void shiftChanged( double xShift, double yShift, double zShift );
 	//! Emitted, if the viewport shift is changed
@@ -114,31 +114,31 @@ signals:
 
 
 public slots:
-	void setRotation( double xVal, double yVal, double zVal ); 																														
-	void setShift( double xVal, double yVal, double zVal );    																														
-	void setViewportShift( double xVal, double yVal );         																														
-	void setScale( double xVal, double yVal, double zVal );    																														
-	void setZoom( double );                                    																														
-  void setOrtho(bool);                                       																														
-  
-	void enableMouse(bool val=true); //!< Enable mouse input   																														
-	void disableMouse(bool val =true); //!< Disable mouse input																														
-	void enableKeyboard(bool val=true); //!< Enable keyboard input   																														
-	void disableKeyboard(bool val =true); //!< Disable keyboard input																														
+	void setRotation( double xVal, double yVal, double zVal );
+	void setShift( double xVal, double yVal, double zVal );
+	void setViewportShift( double xVal, double yVal );
+	void setScale( double xVal, double yVal, double zVal );
+	void setZoom( double );
+  void setOrtho(bool);
+
+	void enableMouse(bool val=true); //!< Enable mouse input
+	void disableMouse(bool val =true); //!< Disable mouse input
+	void enableKeyboard(bool val=true); //!< Enable keyboard input
+	void disableKeyboard(bool val =true); //!< Disable keyboard input
 
   void enableLighting(bool val = true); //!< Turn Lighting on or off
   void disableLighting(bool val = true); //!< Turn Lighting on or off
   //! Rotate ligthsource[idx]
-  void setLightRotation( double xVal, double yVal, double zVal, unsigned int idx = 0 ); 																														
+  void setLightRotation( double xVal, double yVal, double zVal, unsigned int idx = 0 );
   //! Shift ligthsource[idx]
-	void setLightShift( double xVal, double yVal, double zVal, unsigned int idx = 0 );    																														
+	void setLightShift( double xVal, double yVal, double zVal, unsigned int idx = 0 );
 
 
 protected:
 	void mousePressEvent( QMouseEvent *e );
 	void mouseReleaseEvent( QMouseEvent *e );
 	void mouseMoveEvent( QMouseEvent *e );
-	void wheelEvent( QWheelEvent *e );		
+	void wheelEvent( QWheelEvent *e );
   void keyPressEvent( QKeyEvent *e );
 
 	void initializeGL();
@@ -146,21 +146,21 @@ protected:
   void applyLights();
 
 private:
-  // trafos  
+  // trafos
   GLdouble xRot_, yRot_, zRot_, xShift_, yShift_, zShift_, zoom_
            , xScale_, yScale_, zScale_, xVPShift_, yVPShift_;
-	
+
 	bool ortho_;
-	
+
   // mouse
   QPoint lastMouseMovePosition_;
 	bool mpressed_;
 
-	MouseState xrot_mstate_, 
-			yrot_mstate_, 
-			zrot_mstate_, 
-			xscale_mstate_, 
-			yscale_mstate_, 
+	MouseState xrot_mstate_,
+			yrot_mstate_,
+			zrot_mstate_,
+			xscale_mstate_,
+			yscale_mstate_,
 			zscale_mstate_,
       zoom_mstate_,
 			xshift_mstate_,
@@ -175,11 +175,11 @@ private:
   // keyboard
 	bool kpressed_;
 
-	KeyboardState xrot_kstate_[2], 
-			yrot_kstate_[2], 
-			zrot_kstate_[2], 
-			xscale_kstate_[2], 
-			yscale_kstate_[2], 
+	KeyboardState xrot_kstate_[2],
+			yrot_kstate_[2],
+			zrot_kstate_[2],
+			xscale_kstate_[2],
+			yscale_kstate_[2],
 			zscale_kstate_[2],
       zoom_kstate_[2],
 			xshift_kstate_[2],
@@ -194,9 +194,9 @@ private:
 
   // lighting
   struct Light
-  {  
+  {
     Light() : unlit(true){}
-    bool unlit;  
+    bool unlit;
     Qwt3D::Triple rot;
     Qwt3D::Triple shift;
   };

--- a/include/qwt3d_graphplot.h
+++ b/include/qwt3d_graphplot.h
@@ -14,8 +14,8 @@ class QWT3D_EXPORT GraphPlot : public Plot3D
 //    Q_OBJECT
 
 public:
-    GraphPlot( QWidget * parent = 0, const QGLWidget * shareWidget = 0 );
- 
+    GraphPlot( QWidget * parent = 0 );
+
     int createDataset(Qwt3D::TripleVector const& nodes, Qwt3D::EdgeVector const& edges, bool append = false);
 
 protected:

--- a/include/qwt3d_gridplot.h
+++ b/include/qwt3d_gridplot.h
@@ -10,14 +10,14 @@ namespace Qwt3D
 //! A class representing  grid-generated surfaces
 /**
   A GridPlot ...
-  
+
 */
 class QWT3D_EXPORT GridPlot : public SurfacePlot
 {
     Q_OBJECT
 
 public:
-    GridPlot(QWidget* parent = 0, const QGLWidget* shareWidget = 0);
+    GridPlot(QWidget* parent = 0);
     virtual ~GridPlot() {}
 
     int	resolution() const {return resolution_p;} //!< Returns data resolution (1 means all data)
@@ -27,14 +27,14 @@ public:
     int createDataset(double** data, unsigned int columns, unsigned int rows,
                       double minx, double maxx, double miny, double maxy, bool append = false);
 
-	/**		
+	/**
 		Sets number of rendering threads using glDrawArrays to \a count (1..10, 8 by default).
 		If \a count = 0, the older (list based, slow) implementation will be used.
 		\since 0.3.2
 		\sa renderThreadsCount
 	*/
 	void setRenderThreadsCount(int count);
-	/**		
+	/**
 		Returns number of rendering threads using glDrawArrays (8 by default).
 		If this value is 0, the older (list based, slow) implementation is used.
 		\since 0.3.2
@@ -48,7 +48,7 @@ signals:
 public slots:
     void setResolution(int);
 
-protected:  
+protected:
     virtual void createOpenGlData(const Plotlet& pl);
 	virtual void drawOpenGlData();
 	void processVertex(const Triple& vert1, const Triple& norm1, const Color& colorData, bool hl, bool& stripStarted, RGBA& lastColor) const;
@@ -92,7 +92,7 @@ protected:
 	public:
 		CVertexProcessor();
 
-		void setup(int dataWidth, int dataLength, const GridData& data, int row, int step, 
+		void setup(int dataWidth, int dataLength, const GridData& data, int row, int step,
 			bool useColorMap, const Qwt3D::RGBA& fixedColor, const Color* colorData = NULL,
 			bool showMesh = false, const Qwt3D::RGBA& meshColor = Qwt3D::RGBA(0,0,0,0));
 

--- a/include/qwt3d_meshplot.h
+++ b/include/qwt3d_meshplot.h
@@ -8,14 +8,14 @@ namespace Qwt3D
 {
 //! A class representing plots based on points, edges, cells etc.
 /**
-	A MeshPlot is more general compared with a GridPlot, in providing 
-  surface elements built not from a fixed rectangular grid. There is a cost, 
+	A MeshPlot is more general compared with a GridPlot, in providing
+  surface elements built not from a fixed rectangular grid. There is a cost,
   as usual. In this case, it means efficiency.
 */
 class QWT3D_EXPORT MeshPlot : public SurfacePlot
 {
 public:
-  MeshPlot( QWidget * parent = 0, const QGLWidget * shareWidget = 0 );
+  MeshPlot( QWidget * parent = 0 );
   virtual ~MeshPlot() {}
 
   int createDataset(Qwt3D::TripleVector const& data, Qwt3D::CellVector const& poly, bool append = false);
@@ -37,21 +37,21 @@ private:
     MeshData* clone() const {return new MeshData(*this);}
 
     bool empty() const { return cells.empty();}
-  	
+
 	  Triple const& operator()(unsigned cellnumber, unsigned vertexnumber);
-  	
-	  CellVector cells;   //!< polygon/cell mesh 
+
+	  CellVector cells;   //!< polygon/cell mesh
 	  TripleVector    nodes; //!< point cloud
 	  TripleVector    normals; //!< mesh normals
   };
- 
+
   FLOORSTYLE floorstyle_;
-  
+
   void data2Floor(const Plotlet& pl);
   void isolines2Floor(const Plotlet& pl);
   void setColorFromVertex(const Plotlet& pl, int node, bool skip = false);
 };
 
 } // ns
-	
+
 #endif /* include guard */

--- a/include/qwt3d_openglhelper.h
+++ b/include/qwt3d_openglhelper.h
@@ -3,7 +3,7 @@
 #define qwt3d_openglhelper_h__2009_10_11_14_23_25_begin_guarded_code
 
 //#include <qglobal.h>
-#include <QtOpenGL/qgl.h>
+#include <QOpenGLWidget>
 #ifdef Q_OS_MAC
 #include <OpenGL/glu.h>
 #else

--- a/include/qwt3d_plot3d.h
+++ b/include/qwt3d_plot3d.h
@@ -24,10 +24,10 @@ class QWT3D_EXPORT Plot3D : public ExtGLWidget
     Q_OBJECT
 
 public:
-    Plot3D (QWidget * parent = 0, const QGLWidget * shareWidget = 0);
+    Plot3D (QWidget * parent = 0);
     virtual ~Plot3D();
 
-    QPixmap renderPixmap (int w=0, int h=0, bool useContext=false);
+    QPixmap renderPixmap (int w=0, int h=0);
 
     void updateData(); //!< Recalculate data
 
@@ -37,7 +37,7 @@ public:
     void createCoordinateSystem(Qwt3D::Triple beg, Qwt3D::Triple end);
     void setCoordinateStyle(Qwt3D::COORDSTYLE st); //!< Sets style of coordinate system.
 
-    Qwt3D::ColorLegend* legend() { return &legend_;} //!< Returns pointer to ColorLegend object
+    Qwt3D::ColorLegend* legend(); //!< Returns pointer to ColorLegend object
     void showColorLegend(bool show, unsigned idx = 0);
     //! \since 0.3.1
     bool isLegendVisible() const { return displaylegend_; }
@@ -61,7 +61,7 @@ public:
     //! Returns number of Plotlets
     unsigned plotlets() const {return plotlets_p.size();}
     //! Returns false, if at least one valid dataset exists.
-    inline bool hasData() const;
+    bool hasData() const;
     //! Returns appearance for Plotlet at position idx
     inline Appearance& appearance(unsigned idx);
     //! Returns appearance for Plotlet at position idx
@@ -103,7 +103,7 @@ public:
 public slots:
     virtual bool save(QString const& fileName, QString const& format); //!<  Saves content
 
-protected:   
+protected:
     enum OBJECTS
     {
         DataObject,
@@ -131,7 +131,7 @@ protected:
     void resizeGL(int w, int h);
 
     Qwt3D::CoordinateSystem coordinates_p;
-    
+
     virtual	void calculateHull();
     virtual void updateAppearances();
     virtual void createOpenGlData();
@@ -194,17 +194,9 @@ private:
 };
 
 
-// Inline functions
-
-bool Plot3D::hasData() const 
-{
-    return plotlets() > 0 && !plotlets_p[0].data->empty();
-}
-
-
 /**
 The function returns the Appearance object for the Plotlet at idx.
-For invalid arguments the return value contains the standard appearance 
+For invalid arguments the return value contains the standard appearance
 (equivalent to idx==0) is returned
 */
 Appearance& Plot3D::appearance(unsigned idx)
@@ -217,7 +209,7 @@ Appearance& Plot3D::appearance(unsigned idx)
 
 /**
 The function returns the Appearance object for the Plotlet at idx.
-For invalid arguments the return value contains the standard appearance 
+For invalid arguments the return value contains the standard appearance
 (equivalent to idx==0) is returned
 */
 const Appearance& Plot3D::appearance(unsigned idx) const

--- a/include/qwt3d_surfaceplot.h
+++ b/include/qwt3d_surfaceplot.h
@@ -9,14 +9,14 @@ namespace Qwt3D
 //! A class representing  Surfaces
 /**
 	A SurfacePlot ...
-	
+
 */
 class QWT3D_EXPORT SurfacePlot : public Plot3D
 {
   Q_OBJECT
 
 public:
-  SurfacePlot( QWidget * parent = 0, const QGLWidget * shareWidget = 0 );
+  SurfacePlot( QWidget * parent = 0 );
 
   void showNormals(bool); //!< Draw normals to every vertex
   bool normals() const { return datanormals_p;} //!< Returns \c true, if normal drawing is on
@@ -30,7 +30,7 @@ public:
   //! Delete Plotlet with index idx.
   bool removePlotlet(unsigned idx);
 
-protected:  
+protected:
   bool datanormals_p;
   double normalLength_p;
   int normalQuality_p;

--- a/include/qwt3d_types.h
+++ b/include/qwt3d_types.h
@@ -9,16 +9,8 @@
 #include <string>
 
 #include <QtGlobal>
-#if __cplusplus <= 199711L  // c++98 or older
-#   if defined(Q_OS_WIN)
-#      include <windows.h>
-#      define IS_NAN(x) _isnan(x)
-#   else
-#      define IS_NAN(x) isnan(x)
-#   endif
-#else
-#   define IS_NAN(x) std::isnan(x)
-#endif
+#include <math.h>
+#define IS_NAN(x) std::isnan(x)
 
 
 #include "qwt3d_portability.h"

--- a/include/qwt3d_types.h
+++ b/include/qwt3d_types.h
@@ -9,14 +9,17 @@
 #include <string>
 
 #include <QtGlobal>
-#if defined(Q_OS_WIN)
-	#include <windows.h>
-
-    #define IS_NAN(x) std::_isnan(x)
+#if __cplusplus <= 199711L  // c++98 or older
+#   if defined(Q_OS_WIN)
+#      include <windows.h>
+#      define IS_NAN(x) _isnan(x)
+#   else
+#      define IS_NAN(x) isnan(x)
+#   endif
 #else
-    #include <cmath>
-    #define IS_NAN(x) std::isnan(x)
+#   define IS_NAN(x) std::isnan(x)
 #endif
+
 
 #include "qwt3d_portability.h"
 #include "qwt3d_helper.h"
@@ -34,7 +37,7 @@ enum PLOTSTYLE
 	NOPLOT     , //!< No visible data
 	WIREFRAME  , //!< Wireframe style
 	HIDDENLINE , //!< Hidden Line style
-	FILLED     , //!< Color filled polygons w/o edges 
+	FILLED     , //!< Color filled polygons w/o edges
 	FILLEDMESH , //!< Color filled polygons w/ separately colored edges
 	POINTS     , //!< User defined style (used by Enrichments)
 	USER         //!< User defined style (used by Enrichments)
@@ -50,7 +53,7 @@ enum SHADINGSTYLE
 //! Style of Coordinate system
 enum COORDSTYLE
 {
-	NOCOORD, //!< Coordinate system is not visible 
+	NOCOORD, //!< Coordinate system is not visible
 	BOX,     //!< Boxed
 	FRAME		 //!< Frame - 3 visible axes
 };
@@ -58,7 +61,7 @@ enum COORDSTYLE
 //! Different types of axis scales
 enum SCALETYPE
 {
-	LINEARSCALE,//!< Linear scaling 
+	LINEARSCALE,//!< Linear scaling
 	LOG10SCALE,	//!< Logarithmic scaling (base 10)
 	USERSCALE   //!< User-defined (for extensions)
 };
@@ -73,7 +76,7 @@ enum FLOORSTYLE
 
 //! The 12 axes
 /**
-\image html axes.png 
+\image html axes.png
 */
 enum AXIS
 {
@@ -124,7 +127,7 @@ struct QWT3D_EXPORT Tuple
 	Tuple() : x(0), y(0) {} //!< Calls Tuple(0,0)
 	Tuple(double X, double Y) : x(X), y(Y) {} //!< Initialize Tuple with x and y
 	//! Tuple coordinates
-  double x,y; 
+  double x,y;
 };
 
 //! Triple <tt>[x,y,z]</tt>
@@ -134,11 +137,11 @@ Consider Triples also as vectors in R^3
 struct QWT3D_EXPORT Triple
 {
 	//! Initialize Triple with x,y and z
-	explicit Triple(double xv = 0,double yv = 0,double zv = 0) 
+	explicit Triple(double xv = 0,double yv = 0,double zv = 0)
 		: x(xv), y(yv), z(zv)
 	{
 	}
-	
+
 #ifndef QWT3D_NOT_FOR_DOXYGEN
 #ifdef Q_OS_IRIX
   Triple(const Triple& val)
@@ -158,11 +161,11 @@ struct QWT3D_EXPORT Triple
     z = val.z;
     return *this;
   }
-#endif 
+#endif
 #endif // QWT3D_NOT_FOR_DOXYGEN
-  
+
 	//! Triple coordinates
-	double x,y,z; 
+	double x,y,z;
 
 	Triple& operator+=(const Triple& t)
 	{
@@ -172,7 +175,7 @@ struct QWT3D_EXPORT Triple
 
 		return *this;
 	}
-	
+
 	Triple& operator-=(const Triple& t)
 	{
 		x -= t.x;
@@ -213,7 +216,7 @@ struct QWT3D_EXPORT Triple
 	{
 		return !isPracticallyZero(x,t.x) || !isPracticallyZero(y,t.y) || !isPracticallyZero(z,t.z);
 	}
-	
+
 	bool operator==(const Triple& t) const
 	{
 		return !operator!=(t);
@@ -224,7 +227,7 @@ struct QWT3D_EXPORT Triple
 		double l2 = x*x + y*y + z*z;
 		return (isPracticallyZero(l2)) ? 0 :sqrt(l2);
 	}
-	
+
 	void normalize()
 	{
 		double l = length();
@@ -314,7 +317,7 @@ struct QWT3D_EXPORT ParallelEpiped
 	: minVertex(minv), maxVertex(maxv)
 	{
 	}
-	
+
 	Triple minVertex;
 	Triple maxVertex;
 };
@@ -322,21 +325,21 @@ struct QWT3D_EXPORT ParallelEpiped
 inline ParallelEpiped sum(const ParallelEpiped& a, const ParallelEpiped& b)
 {
   Triple mi = a.minVertex - b.minVertex;
-  mi.x = (mi.x<0) ? a.minVertex.x : b.minVertex.x; 
-  mi.y = (mi.y<0) ? a.minVertex.y : b.minVertex.y; 
-  mi.z = (mi.z<0) ? a.minVertex.z : b.minVertex.z; 
-  
+  mi.x = (mi.x<0) ? a.minVertex.x : b.minVertex.x;
+  mi.y = (mi.y<0) ? a.minVertex.y : b.minVertex.y;
+  mi.z = (mi.z<0) ? a.minVertex.z : b.minVertex.z;
+
   Triple ma = a.maxVertex - b.maxVertex;
-  ma.x = (ma.x>0) ? a.maxVertex.x : b.maxVertex.x; 
-  ma.y = (ma.y>0) ? a.maxVertex.y : b.maxVertex.y; 
-  ma.z = (ma.z>0) ? a.maxVertex.z : b.maxVertex.z; 
+  ma.x = (ma.x>0) ? a.maxVertex.x : b.maxVertex.x;
+  ma.y = (ma.y>0) ? a.maxVertex.y : b.maxVertex.y;
+  ma.z = (ma.z>0) ? a.maxVertex.z : b.maxVertex.z;
 
   return ParallelEpiped(mi, ma);
 }
 
 //! Free vector
 /**
-	FreeVectors represent objects like normal vectors and other vector fields inside R^3 
+	FreeVectors represent objects like normal vectors and other vector fields inside R^3
 */
 struct QWT3D_EXPORT FreeVector
 {
@@ -353,7 +356,7 @@ struct QWT3D_EXPORT FreeVector
 	: base(b), top(t)
 	{
 	}
-	
+
 	Triple base;
 	Triple top;
 };
@@ -382,7 +385,7 @@ struct QWT3D_EXPORT RGBA
 	RGBA()
 		: r(0), g(0), b(0), a(1)
 		{}
-	
+
 	RGBA(double rr, double gg, double bb, double aa = 1)
 		: r(rr), g(gg), b(bb), a(aa)
 		{}
@@ -421,7 +424,7 @@ inline Triple normalizedcross(Triple const& u, Triple const& v)
 
 	/* normalize */
 	n.normalize();
-	
+
 	return n;
 }
 
@@ -433,7 +436,7 @@ inline double dotProduct(Triple const& u, Triple const& v)
 void convexhull2d( std::vector<unsigned>& idx, const std::vector<Qwt3D::Tuple>& src );
 
 
-#endif // QWT3D_NOT_FOR_DOXYGEN 
+#endif // QWT3D_NOT_FOR_DOXYGEN
 
 } // ns
 

--- a/include/qwt3d_volumeplot.h
+++ b/include/qwt3d_volumeplot.h
@@ -51,7 +51,7 @@ struct Voxel
 class QWT3D_EXPORT VolumePlot : public Plot3D
 {
 public:
-    VolumePlot(QWidget *parent = 0, const QGLWidget *shareWidget = 0);
+    VolumePlot(QWidget *parent = 0);
 
     int createDataset(Voxel::Array const &nodes, bool append = false);
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,15 @@
-		QwtPlot3d 0.3.1a
+		QwtPlot3d 0.3.2
 
 	--------------------------------
 	http://qwtplot3d.sourceforge.net
 
+
+Version 0.3.2 - May 2020
+---------------------------------------------------------------------------
+- fixed building issues with ealier versions of Visual Studio
+- fixed building issues on unix
+- replaced QGLWidget with QOpenGLWidget
+- Known issues: some examples are not working anymore
 
 
 Version 0.3.1a - Sep 2014
@@ -26,11 +33,14 @@ License notes
 ---------------------------------------------------------------------------
 This distribution is mainly based on QwtPlot3d 0.3.0 revision 259
 (http://sourceforge.net/p/qwtplot3d/code/HEAD/tree/)
-
-Parts of the software are provided by Sintegrial Technologies (c) 2013-2014
+and further revions provided by Sintegrial Technologies (c) 2013-2014
 (http://sintegrial.com)
+(https://github.com/sintegrial/qwtplot3d)
 
-Extensions made by Sintegrial Technologies are provided 'as-is', without
+Parts of the software are provided by Applied Coherent Technologies Corporation (c) 2001-2020
+(http://www.actgate.com)
+
+Extensions made by Applied Coherent Technologies Corporation are provided 'as-is', without
 any warranty. They are granted under the terms of the original QwtPlot3D 
 license.
 

--- a/src/qwt3d_axis.cpp
+++ b/src/qwt3d_axis.cpp
@@ -110,6 +110,15 @@ void Axis::setLineWidth(double val, double majfac, double minfac)
     minLineWidth_ = minfac * lineWidth_;
 }
 
+/*!
+  Returns axis interval
+*/
+void Axis::limits(double& start, double& stop) const
+{
+	start = start_;
+	stop = stop_;
+}
+
 void Axis::draw()
 {
     Drawable::draw();
@@ -173,7 +182,7 @@ void Axis::drawBase()
     glVertex3d( beg_.x, beg_.y, beg_.z);
     glVertex3d( end_.x, end_.y, end_.z);
     glEnd();
-}   
+}
 
 bool Axis::prepTicCalculation(Triple& startpoint)
 {
@@ -237,7 +246,7 @@ void Axis::drawTics()
 
     unsigned int i;
     Triple nadir;
-    
+
     markerLabel_.resize(scale_->majors_p.size());
     setLineWidth(majLineWidth_);
     for (i = 0; i != scale_->majors_p.size(); ++i)
@@ -260,7 +269,7 @@ void Axis::drawTicLabel(Triple pos, int mtic)
 {
     if (!drawNumbers_ || (mtic < 0))
         return;
-    
+
     markerLabel_[mtic].setFont(numberfont_.family(), numberfont_.pointSize(), numberfont_.weight(), numberfont_.italic());
     markerLabel_[mtic].setColor(numbercolor_);
     markerLabel_[mtic].setString(scale_->ticLabel(mtic));
@@ -330,7 +339,7 @@ void Axis::setLabelColor(RGBA col)
     label_.setColor(col);
 }
 
-/*! 
+/*!
   This variant sets a user-defined scale object.
   Use with a heap based initialized pointer only.
   The axis adopts ownership.

--- a/src/qwt3d_drawable.cpp
+++ b/src/qwt3d_drawable.cpp
@@ -79,7 +79,7 @@ void Drawable::detachAll()
 }
 
 
-//! simplified glut routine (glUnProject): windows coordinates_p --> object coordinates_p 
+//! simplified glut routine (glUnProject): windows coordinates_p --> object coordinates_p
 /**
 	Don't rely on (use) this in display lists !
 */
@@ -95,7 +95,7 @@ Triple Drawable::ViewPort2World(Triple win, bool* err)
 	return obj;
 }
 
-//! simplified glut routine (glProject): object coordinates_p --> windows coordinates_p 
+//! simplified glut routine (glProject): object coordinates_p --> windows coordinates_p
 /**
 	Don't rely on (use) this in display lists !
 */
@@ -127,15 +127,16 @@ void Drawable::draw()
 	{
 		(*it)->draw();
 	}
+
 	restoreGLState();
 }
 
 void Drawable::setColor(double r, double g, double b, double a)
 {
 	color = RGBA(r,g,b,a);
-}	
+}
 
 void Drawable::setColor(RGBA rgba)
 {
 	color = rgba;
-}	
+}

--- a/src/qwt3d_extglwidget.cpp
+++ b/src/qwt3d_extglwidget.cpp
@@ -17,9 +17,9 @@ using namespace Qwt3D;
 /*!
   This should be the first call in your derived classes constructors.
 */
-ExtGLWidget::ExtGLWidget( QWidget * parent, const QGLWidget * shareWidget)
-    : QGLWidget( parent, shareWidget)
-{  
+ExtGLWidget::ExtGLWidget( QWidget * parent)
+    : QOpenGLWidget( parent )
+{
     initializedGL_ = false;
     xRot_ = yRot_ = zRot_ = 0.0;		// default object rotation
 
@@ -225,14 +225,14 @@ void ExtGLWidget::assignMouse(MouseState xrot, MouseState yrot, MouseState zrot,
     yshift_mstate_ =  yshift;
 }
 
-/** 
+/**
 The function has no effect if you derive from ExtGLWidget and overrides the mouse Function too careless.
 In this case check first against mouseEnabled() in your version of mouseMoveEvent() and wheelEvent().
-A more fine grained input control can be achieved by combining assignMouse() with enableMouse(). 
+A more fine grained input control can be achieved by combining assignMouse() with enableMouse().
 */
 void ExtGLWidget::enableMouse(bool val) {mouse_input_enabled_ = val;}
 
-/** 
+/**
 \see enableMouse()
 */
 void ExtGLWidget::disableMouse(bool val) {mouse_input_enabled_ = !val;}
@@ -394,14 +394,14 @@ void ExtGLWidget::assignKeyboard(
     yshift_kstate_[1] =  yshift_p;
 }
 
-/** 
+/**
 The function has no effect if you derive from ExtGLWidget and overrides the keyboard Functions too careless.
 In this case check first against keyboardEnabled() in your version of keyPressEvent()
-A more fine grained input control can be achieved by combining assignKeyboard() with enableKeyboard(). 
+A more fine grained input control can be achieved by combining assignKeyboard() with enableKeyboard().
 */
 void ExtGLWidget::enableKeyboard(bool val) {kbd_input_enabled_ = val;}
 
-/** 
+/**
 \see enableKeyboard()
 */
 void ExtGLWidget::disableKeyboard(bool val) {kbd_input_enabled_ = !val;}
@@ -443,7 +443,7 @@ void ExtGLWidget::setRotation( double xVal, double yVal, double zVal )
     yRot_ = yVal;
     zRot_ = zVal;
 
-    updateGL();
+    update();
     emit rotationChanged(xVal, yVal, zVal);
 }
 
@@ -462,7 +462,7 @@ void ExtGLWidget::setShift( double xVal, double yVal, double zVal )
     xShift_ = xVal;
     yShift_ = yVal;
     zShift_ = zVal;
-    updateGL();
+    update();
     emit shiftChanged(xVal, yVal, zVal);
 }
 
@@ -484,7 +484,7 @@ void ExtGLWidget::setViewportShift( double xVal, double yVal )
     xVPShift_ = xVal;
     yVPShift_ = yVal;
 
-    updateGL();
+    update();
     emit vieportShiftChanged(xVPShift_, yVPShift_);
 }
 
@@ -505,7 +505,7 @@ void ExtGLWidget::setScale( double xVal, double yVal, double zVal )
     yScale_ = (yVal < DBL_EPSILON ) ? DBL_EPSILON : yVal;
     zScale_ = (zVal < DBL_EPSILON ) ? DBL_EPSILON : zVal;
 
-    updateGL();
+    update();
     emit scaleChanged(xVal, yVal, zVal);
 }
 
@@ -519,7 +519,7 @@ void ExtGLWidget::setZoom( double val )
         return;
 
     zoom_ = (val < DBL_EPSILON ) ? DBL_EPSILON : val;
-    updateGL();
+    update();
     emit zoomChanged(val);
 }
 
@@ -531,7 +531,7 @@ void ExtGLWidget::setOrtho( bool val )
     if (val == ortho_)
         return;
     ortho_ = val;
-    updateGL();
+    update();
 
     emit projectionChanged(val);
 }
@@ -550,7 +550,7 @@ void ExtGLWidget::initializeGL()
     disableLighting();
 
     GLfloat whiteAmb[4] = {1.0, 1.0, 1.0, 1.0};
-    
+
     setLightShift(0, 0, 3000);
     glEnable(GL_COLOR_MATERIAL);
 

--- a/src/qwt3d_graphplot.cpp
+++ b/src/qwt3d_graphplot.cpp
@@ -1,6 +1,6 @@
 #if defined(_MSC_VER) /* MSVC Compiler */
 /* 'identifier' : truncation from 'type1' to 'type2' */
-#pragma warning ( disable : 4305 ) 
+#pragma warning ( disable : 4305 )
 #endif
 
 
@@ -12,7 +12,7 @@ using namespace Qwt3D;
 // Data class (private)
 
 
-GraphPlot::GraphData::GraphData() 
+GraphPlot::GraphData::GraphData()
 {
   datatype_p=Qwt3D::GRAPH;
   setHull(ParallelEpiped());
@@ -33,8 +33,8 @@ bool GraphPlot::GraphData::empty() const
 // Data class end
 
 
-GraphPlot::GraphPlot( QWidget * parent, const QGLWidget * shareWidget)
-: Plot3D( parent, shareWidget) 
+GraphPlot::GraphPlot( QWidget * parent )
+: Plot3D( parent )
 {
   plotlets_p[0].data = ValuePtr<Data>(new GraphData);
 }
@@ -62,7 +62,7 @@ void GraphPlot::createOpenGlData(const Plotlet& pl)
   // 	if (plotStyle() != WIREFRAME)
   // 	{
   // 		glPolygonMode(GL_FRONT_AND_BACK, GL_QUADS);
-  // 
+  //
   // 		bool hl = (plotStyle() == HIDDENLINE);
   // 		if (hl)
   // 		{
@@ -71,7 +71,7 @@ void GraphPlot::createOpenGlData(const Plotlet& pl)
   // 		}
 
   /*
-  RGBA col(0.8,0,0);    
+  RGBA col(0.8,0,0);
   glColor4d(col.r, col.g, col.b, col.a);
   glBegin(GL_LINES);
   for (unsigned i=0; i!=data_->edges.size(); ++i)
@@ -84,7 +84,7 @@ void GraphPlot::createOpenGlData(const Plotlet& pl)
   }
   glEnd();
 
-  col = RGBA(0,0,0.5);    
+  col = RGBA(0,0,0.5);
   glColor4d(col.r, col.g, col.b, col.a);
   setDevicePointSize( 4 );
   glBegin(GL_POINTS);
@@ -111,7 +111,7 @@ void GraphPlot::createOpenGlData(const Plotlet& pl)
   Ball b((hull().maxVertex-hull().minVertex).length() / 50, 32);
   //static bool ff = true;
   //if (ff)
-  b.setColor(RGBA(0.5,0,0));    
+  b.setColor(RGBA(0.5,0,0));
   //else
   //  b.setColor(RGBA(0,0.5,0));
   //ff = !ff;
@@ -124,7 +124,7 @@ void GraphPlot::createOpenGlData(const Plotlet& pl)
   //	}
 }
 
-/*! 
+/*!
 Convert user defined graph data to internal structure.
 See also Qwt3D::TripleVector and Qwt3D::EdgeVector
 
@@ -133,7 +133,7 @@ be replaced by the new data. This includes destruction of possible additional da
 \return Index of new entry in dataset array (append == true), 0 (append == false) or -1 for errors
 */
 int GraphPlot::createDataset(TripleVector const& nodes, EdgeVector const& edges, bool append /*= false*/)
-{	
+{
 
   int ret = prepareDatasetCreation<GraphData>(append);
   if (ret < 0)
@@ -148,4 +148,4 @@ int GraphPlot::createDataset(TripleVector const& nodes, EdgeVector const& edges,
   createCoordinateSystem();
 
   return ret;
-}	
+}

--- a/src/qwt3d_gridplot.cpp
+++ b/src/qwt3d_gridplot.cpp
@@ -29,13 +29,13 @@ GridPlot::GridData::GridData(unsigned int columns, unsigned int rows)
     setPeriodic(false,false);
 }
 
-int GridPlot::GridData::columns() const 
-{ 
+int GridPlot::GridData::columns() const
+{
     return (int)vertices.size();
 }
 
-int GridPlot::GridData::rows() const 
-{ 
+int GridPlot::GridData::rows() const
+{
     return (empty()) ? 0 : (int)vertices[0].size();
 }
 
@@ -123,7 +123,7 @@ void GridPlot::CVertexProcessor::run()
 	m_mesh_vertices.clear();
 	m_mesh_colors.clear();
 	m_drawMeshList.clear();
-	
+
 	if (m_drawMesh && m_dataLength*m_dataWidth)
 	{
 		int index = 0;
@@ -153,7 +153,7 @@ void GridPlot::CVertexProcessor::run()
             }
 
 			endLineVertex(index, size);
-		}		
+		}
 	}
 }
 
@@ -273,8 +273,8 @@ void GridPlot::CVertexProcessor::paintGL()
 /**
 	Initializes with dataNormals()==false, NOFLOOR, resolution() == 1
 */
-GridPlot::GridPlot(QWidget* parent, const QGLWidget* shareWidget)
-    : SurfacePlot(parent, shareWidget),
+GridPlot::GridPlot(QWidget* parent)
+    : SurfacePlot(parent),
 	m_threadsCount(0),
 	m_useThreads(false)
 {
@@ -289,7 +289,7 @@ void GridPlot::setColorFromVertex(const Color& colorData, const Triple& vertex, 
 
     RGBA col = colorData.rgba(vertex);
 	if (lastColor != col)
-	{ 
+	{
 		glColor4d(col.r, col.g, col.b, col.a);
 		lastColor = col;
 	}
@@ -369,7 +369,7 @@ void GridPlot::readIn(GridData& gdata, Triple** data, unsigned int columns, unsi
 }
 
 
-void GridPlot::readIn(GridData& gdata, double** data, unsigned int columns, unsigned int rows, 
+void GridPlot::readIn(GridData& gdata, double** data, unsigned int columns, unsigned int rows,
 					  double minx, double maxx, double miny, double maxy)
 {
     gdata.setPeriodic(false,false);
@@ -558,7 +558,7 @@ void GridPlot::sewPeriodic(GridData& gdata)
   be replaced by the new data. This includes destruction of possible additional datasets/Plotlets.
   \return Index of new entry in dataset array (append == true), 0 (append == false) or -1 for errors
   */
-int GridPlot::createDataset(Triple** data, unsigned int columns, unsigned int rows, 
+int GridPlot::createDataset(Triple** data, unsigned int columns, unsigned int rows,
                             bool uperiodic /*=false*/, bool vperiodic /*=false*/, bool append /*= false*/)
 {
 	// block possible active threads
@@ -579,9 +579,9 @@ int GridPlot::createDataset(Triple** data, unsigned int columns, unsigned int ro
     createCoordinateSystem();
 
     return ret;
-}	
+}
 
-/*! 
+/*!
   Convert user grid data to internal vertex structure.
   See also NativeReader::operator() and Function::create()
 
@@ -591,7 +591,7 @@ int GridPlot::createDataset(Triple** data, unsigned int columns, unsigned int ro
   */
 int GridPlot::createDataset(double** data, unsigned int columns, unsigned int rows,
                             double minx, double maxx, double miny, double maxy, bool append /*= false*/)
-{	
+{
 	// block possible active threads
 	m_useThreads = false;
 
@@ -624,7 +624,7 @@ int GridPlot::createDataset(double** data, unsigned int columns, unsigned int ro
     createCoordinateSystem();
 
     return ret;
-}	
+}
 
 void GridPlot::data2Floor(const Plotlet& pl)
 {
@@ -699,7 +699,7 @@ void GridPlot::isolines2Floor(const Plotlet& pl)
         double val = isolinesZ_p[k];
         if (val > data.hull().maxVertex.z || val < data.hull().minVertex.z)
             continue;
-        
+
         for (int i = 0; i < cols-step; i += step)
         {
             for (int j = 0; j < rows-step; j += step)
@@ -749,7 +749,7 @@ void GridPlot::setResolution(int res)
     updateData();
     updateNormals();
     if (initializedGL())
-        updateGL();
+        update();
 
     emit resolutionChanged(res);
 }
@@ -814,7 +814,7 @@ void GridPlot::createOpenGlData(const Plotlet& pl)
 		if (drawFill)
 		{
 	        glPolygonMode(GL_FRONT_AND_BACK, GL_QUADS);
-	
+
 			if (hl)
 				glColor4d(col.r, col.g, col.b, col.a);
 
@@ -903,7 +903,7 @@ void GridPlot::createOpenGlData(const Plotlet& pl)
 				}
 
 				glEnd();
-			}		
+			}
 		}
 	}
 	else // new glDrawArrays-based render
@@ -919,8 +919,8 @@ void GridPlot::createOpenGlData(const Plotlet& pl)
 			if (i == m_threadsCount-1)
 				length += lastrow - (length * m_threadsCount) - 1;
 
-			m_workers[i].setup(lastcol, length, data, r, step, 
-				!hl, col, drawFill ? &colorData : NULL, 
+			m_workers[i].setup(lastcol, length, data, r, step,
+				!hl, col, drawFill ? &colorData : NULL,
 				drawMesh, app.meshColor());
 
 			m_workers[i].start(QThread::HighPriority);
@@ -967,7 +967,7 @@ void GridPlot::setRenderThreadsCount(int count)
 		m_threadsCount = count;
 }
 
-void GridPlot::processVertex(const Triple& vert1, const Triple& norm1, 
+void GridPlot::processVertex(const Triple& vert1, const Triple& norm1,
 							 const Color& colorData, bool hl, bool& stripStarted,
 							 RGBA& lastColor) const
 {
@@ -987,7 +987,7 @@ void GridPlot::processVertex(const Triple& vert1, const Triple& norm1,
 	else{
 		if (!stripStarted){
 			stripStarted = true;
-            
+
             // degenerated triangle
 			glVertex3d(vert1.x, vert1.y, vert1.z);
             glVertex3d(vert1.x, vert1.y, vert1.z);

--- a/src/qwt3d_label.cpp
+++ b/src/qwt3d_label.cpp
@@ -3,6 +3,8 @@
 
 using namespace Qwt3D;
 
+#include <QPainter>
+
 Label::Label()
 {
   init();
@@ -58,7 +60,7 @@ void Label::setColor(double r, double g, double b, double a)
 {
   Drawable::setColor(r,g,b,a);
   flagforupdate_ = true;
-}   
+}
 
 void Label::setColor(Qwt3D::RGBA rgba)
 {
@@ -71,7 +73,7 @@ example:
 
 \verbatim
 
-   Anchor TopCenter (*)  resp. BottomRight(X) 
+   Anchor TopCenter (*)  resp. BottomRight(X)
 
    +----*----+
    |  Pixmap |
@@ -108,7 +110,7 @@ QImage Label::createImage(double angle)
       aux_a -= 180;
   if (aux_a > 90)
       aux_a -= 90;
-  
+
   double rad = aux_a * PI/180.0;
 
   int w = 0, h = 0;
@@ -116,13 +118,13 @@ QImage Label::createImage(double angle)
   {
       w = qRound(fabs(textWidth*cos(rad) + textHeight*sin(rad)));
       h = qRound(fabs(textWidth*sin(rad) + textHeight*cos(rad)));
-  } 
-  else 
+  }
+  else
   {
       w = qRound(fabs(textWidth*sin(rad) + textHeight*cos(rad)));
       h = qRound(fabs(textWidth*cos(rad) + textHeight*sin(rad)));
   }
-  
+
   width_ = w;
   height_ = h;
   QPixmap pm_ = QPixmap(w, h);
@@ -146,7 +148,8 @@ QImage Label::createImage(double angle)
   p.drawText(0, 0, text_);
   p.end();
 
-  return QGLWidget::convertToGLFormat(pm_.toImage());
+  QImage img = pm_.toImage();
+  return img.mirrored().convertToFormat(QImage::Format_RGBA8888);
 }
 
 /**
@@ -157,7 +160,7 @@ anchor type         shift
 
 left aligned         -->
 right aligned        <--
-top aligned          top-down            
+top aligned          top-down
 bottom aligned       bottom-up
 \endverbatim
 The unit is user space dependent (one pixel on screen - play around to get satisfying results)
@@ -170,7 +173,7 @@ void Label::adjust(int gap)
 void Label::convert2screen()
 {
   Triple start = World2ViewPort(pos_);
-  
+
   switch (anchor_)
   {
     case BottomLeft :
@@ -204,7 +207,7 @@ void Label::convert2screen()
       break;
   }
   start = World2ViewPort(beg_);
-  end_ = ViewPort2World(start + Triple(width(), height(), 0));    
+  end_ = ViewPort2World(start + Triple(width(), height(), 0));
 }
 
 const char * Label::fontname()
@@ -219,7 +222,7 @@ const char * Label::fontname()
       name = "Times-Italic";
     else if (font_.bold())
       name = "Times-Bold";
-  } 
+  }
   else if (font_.family() == "Courier" || font_.family() == "Courier New")
   {
     name = "Courier";
@@ -229,8 +232,8 @@ const char * Label::fontname()
       name = "Courier-Oblique";
     else if (font_.bold())
       name = "Courier-Bold";
-  } 
-  else 
+  }
+  else
   {
     if (font_.bold() && font_.italic ())
       name = "Helvetica-BoldOblique";
@@ -246,7 +249,7 @@ void Label::draw(double angle)
 {
   if (text_.isEmpty())
     return;
-  if ( use_relpos_ ) 
+  if ( use_relpos_ )
   {
     getMatrices(modelMatrix, projMatrix, viewport);
     beg_ = relativePosition(relpos_);
@@ -254,17 +257,17 @@ void Label::draw(double angle)
     use_relpos_ = true;// reset the flag
   }
 
-      
+
   GLboolean b;
   GLint func;
   GLdouble v;
   glGetBooleanv(GL_ALPHA_TEST, &b);
   glGetIntegerv(GL_ALPHA_TEST_FUNC, &func);
   glGetDoublev(GL_ALPHA_TEST_REF, &v);
-  
+
   glEnable (GL_ALPHA_TEST);
   glAlphaFunc (GL_NOTEQUAL, 0.0);
-  
+
   convert2screen();
   glRasterPos3d(beg_.x, beg_.y, beg_.z);
 
@@ -275,19 +278,19 @@ void Label::draw(double angle)
 }
 
 
-double Label::width() const 
-{ 
+double Label::width() const
+{
     if (width_ > 0.0 && height_ > 0.0)
         return width_;
     return QRect(QPoint(0, 0), QFontMetrics(font_).size(Qwt3D::SingleLine, text_)).width();
 }
 
-double Label::height() const 
-{ 
+double Label::height() const
+{
     if (width_ > 0.0 && height_ > 0.0)
         return height_;
     return QRect(QPoint(0, 0), QFontMetrics(font_).size(Qwt3D::SingleLine, text_)).height();
-}   
+}
 double Label::textHeight() const
 {
     return QRect(QPoint(0, 0), QFontMetrics(font_).size(Qwt3D::SingleLine, text_)).height();

--- a/src/qwt3d_lighting.cpp
+++ b/src/qwt3d_lighting.cpp
@@ -49,7 +49,7 @@ void ExtGLWidget::enableLighting(bool val)
 
   if (!initializedGL())
     return;
-  updateGL();
+  update();
 }
 
 void ExtGLWidget::disableLighting(bool val)

--- a/src/qwt3d_lighting.cpp
+++ b/src/qwt3d_lighting.cpp
@@ -39,7 +39,7 @@ void ExtGLWidget::enableLighting(bool val)
 {
   if (lighting_enabled_ == val)
     return;
-  
+
   lighting_enabled_ = val;
   makeCurrent();
   if (val)
@@ -62,47 +62,47 @@ bool ExtGLWidget::lightingEnabled() const
   return lighting_enabled_;
 }
 
-/** 
+/**
   \param light light number [0..7]
-  \see setLight 
+  \see setLight
 */
 void ExtGLWidget::illuminate(unsigned light)
 {
   if (light>7)
-    return;  
-  lights_[light].unlit = false;  
+    return;
+  lights_[light].unlit = false;
 }
 /**
   \param light light number [0..7]
-  \see setLight  
+  \see setLight
 */
 void ExtGLWidget::blowout(unsigned light)
 {
   if (light>7)
     return;
-  lights_[light].unlit = false;  
+  lights_[light].unlit = false;
 }
 
-/** 
+/**
   Sets GL material properties
 */
 void ExtGLWidget::setMaterialComponent(GLenum property, double r, double g, double b, double a)
 {
   GLfloat rgba[4] = {(GLfloat)r, (GLfloat)g, (GLfloat)b, (GLfloat)a};
   makeCurrent();
-  glMaterialfv(GL_FRONT_AND_BACK, property, rgba);  
-}    
+  glMaterialfv(GL_FRONT_AND_BACK, property, rgba);
+}
 
-/** 
-  This function is for convenience. It sets GL material properties with the equal r,g,b values 
-  and a blending alpha with value 1.0 
+/**
+  This function is for convenience. It sets GL material properties with the equal r,g,b values
+  and a blending alpha with value 1.0
 */
 void ExtGLWidget::setMaterialComponent(GLenum property, double intensity)
 {
   setMaterialComponent(property,intensity,intensity,intensity,1.0);
-}    
+}
 
-/** 
+/**
   Sets GL shininess
 */
 void ExtGLWidget::setShininess(double exponent)
@@ -111,7 +111,7 @@ void ExtGLWidget::setShininess(double exponent)
   glMaterialf(GL_FRONT, GL_SHININESS, exponent);
 }
 
-/** 
+/**
   Sets GL light properties for light 'light'
 */
 void ExtGLWidget::setLightComponent(GLenum property, double r, double g, double b, double a, unsigned light)
@@ -119,20 +119,20 @@ void ExtGLWidget::setLightComponent(GLenum property, double r, double g, double 
   GLfloat rgba[4] = {(GLfloat)r, (GLfloat)g, (GLfloat)b, (GLfloat)a};
   makeCurrent();
   glLightfv(lightEnum(light), property, rgba);
-}    
+}
 
-/** 
-  This function is for convenience. It sets GL light properties with the equal r,g,b values 
-  and a blending alpha with value 1.0 
+/**
+  This function is for convenience. It sets GL light properties with the equal r,g,b values
+  and a blending alpha with value 1.0
 */
 void ExtGLWidget::setLightComponent(GLenum property, double intensity, unsigned light)
 {
   setLightComponent(property,intensity,intensity,intensity,1.0, lightEnum(light));
-}    
+}
 
 /**
   Set the rotation angle of the light source. If you look along the respective axis towards ascending values,
-	the rotation is performed in mathematical \e negative sense 
+	the rotation is performed in mathematical \e negative sense
 	\param xVal angle in \e degree to rotate around the X axis
 	\param yVal angle in \e degree to rotate around the Y axis
 	\param zVal angle in \e degree to rotate around the Z axis
@@ -141,7 +141,7 @@ void ExtGLWidget::setLightComponent(GLenum property, double intensity, unsigned 
 void ExtGLWidget::setLightRotation( double xVal, double yVal, double zVal, unsigned light )
 {
 	if (light>7)
-    return; 
+    return;
   lights_[light].rot.x = xVal;
   lights_[light].rot.y = yVal;
   lights_[light].rot.z = zVal;
@@ -158,7 +158,7 @@ void ExtGLWidget::setLightRotation( double xVal, double yVal, double zVal, unsig
 void ExtGLWidget::setLightShift( double xVal, double yVal, double zVal, unsigned light )
 {
 	if (light>7)
-    return; 
+    return;
   lights_[light].shift.x = xVal;
   lights_[light].shift.y = yVal;
   lights_[light].shift.z = zVal;
@@ -171,13 +171,13 @@ void ExtGLWidget::applyLight(unsigned light)
 
   glEnable(lightEnum(light));
   glLoadIdentity();
-  
-  glRotatef( lights_[light].rot.x-90, 1.0, 0.0, 0.0 ); 
-  glRotatef( lights_[light].rot.y   , 0.0, 1.0, 0.0 ); 
+
+  glRotatef( lights_[light].rot.x-90, 1.0, 0.0, 0.0 );
+  glRotatef( lights_[light].rot.y   , 0.0, 1.0, 0.0 );
   glRotatef( lights_[light].rot.z   , 0.0, 0.0, 1.0 );
-  GLfloat lightPos[4] = { (float)lights_[light].shift.x, (float)lights_[light].shift.y, (float)lights_[light].shift.z, 1.0};
+  GLfloat lightPos[4] = { static_cast<GLfloat>(lights_[light].shift.x), static_cast<GLfloat>(lights_[light].shift.y), static_cast<GLfloat>(lights_[light].shift.z), 1.0};
   GLenum le = lightEnum(light);
-  glLightfv(le, GL_POSITION, lightPos);  
+  glLightfv(le, GL_POSITION, lightPos);
 }
 
 void ExtGLWidget::applyLights()

--- a/src/qwt3d_meshplot.cpp
+++ b/src/qwt3d_meshplot.cpp
@@ -26,8 +26,8 @@ MeshPlot::MeshData::~MeshData()
 /**
 Initializes with dataNormals()==false, NOFLOOR, resolution() == 1
 */
-MeshPlot::MeshPlot( QWidget * parent, const QGLWidget * shareWidget)
-    : SurfacePlot( parent, shareWidget)
+MeshPlot::MeshPlot( QWidget * parent )
+    : SurfacePlot( parent )
 {
     plotlets_p[0].data = ValuePtr<Data>(new MeshData);
 }
@@ -49,7 +49,7 @@ void MeshPlot::setColorFromVertex(const Plotlet& pl, int node, bool skip)
 
 
 void MeshPlot::data2Floor(const Plotlet& pl)
-{	
+{
     const MeshData& data = dynamic_cast<const MeshData&>(*pl.data);
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -174,7 +174,7 @@ void MeshPlot::createNormals(const Plotlet& pl)
     arrow.drawEnd();
 }
 
-/*! 
+/*!
 Convert user (non-rectangular) mesh based data to internal structure.
 See also Qwt3D::TripleVector and Qwt3D::CellVector
 
@@ -183,7 +183,7 @@ be replaced by the new data. This includes destruction of possible additional da
 \return Index of new entry in dataset array (append == true), 0 (append == false) or -1 for errors
 */
 int MeshPlot::createDataset(TripleVector const& data, CellVector const& poly, bool append /*= false*/)
-{	
+{
     int ret = prepareDatasetCreation<MeshData>(append);
     if (ret < 0)
         return -1;
@@ -226,7 +226,7 @@ int MeshPlot::createDataset(TripleVector const& data, CellVector const& poly, bo
     createCoordinateSystem();
 
     return ret;
-}	
+}
 
 void MeshPlot::createOpenGlData(const Plotlet& pl)
 {

--- a/src/qwt3d_surfaceplot.cpp
+++ b/src/qwt3d_surfaceplot.cpp
@@ -6,9 +6,9 @@ using namespace Qwt3D;
 /**
 Initializes with dataNormals()==false //todo
 */
-SurfacePlot::SurfacePlot( QWidget * parent, const QGLWidget * shareWidget)
-    : Plot3D( parent, shareWidget)
-{  
+SurfacePlot::SurfacePlot( QWidget * parent )
+    : Plot3D( parent )
+{
     floorstyle_ = NOFLOOR;
     datanormals_p = false;
     normalLength_p = 0.02;
@@ -31,9 +31,9 @@ void SurfacePlot::setNormalLength(double val)
 }
 
 /**
-Values < 3 are ignored 
+Values < 3 are ignored
 */
-void SurfacePlot::setNormalQuality(int val) 
+void SurfacePlot::setNormalQuality(int val)
 {
     if (val<3)
         return;

--- a/src/qwt3d_volumeplot.cpp
+++ b/src/qwt3d_volumeplot.cpp
@@ -13,8 +13,8 @@ namespace Qwt3D
 
 // VolumePlot
 
-VolumePlot::VolumePlot(QWidget *parent, const QGLWidget *shareWidget)
-    : Plot3D(parent, shareWidget)
+VolumePlot::VolumePlot(QWidget *parent)
+    : Plot3D(parent)
 {
     plotlets_p[0].data = ValuePtr<Data>(new GraphData);
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,7 +1,7 @@
 TARGET            = qwtplot3d
 TEMPLATE          = lib
 DESTDIR      	  = ../lib
-CONFIG           += qt warn_on thread static
+CONFIG           += qt warn_on thread static release
 QT               += opengl
 
 SOURCES           = *.cpp
@@ -18,11 +18,9 @@ HEADERS           += ../include/*.h
 INCLUDEPATH       = ../include
 
 win32 {
-  win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 | win32-msvc2015 {
     QMAKE_CXXFLAGS += -MP
     QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_STL
     QMAKE_CXXFLAGS_RELEASE += /fp:fast /arch:SSE2
-  }
 }
 
 linux-g++:QMAKE_CXXFLAGS += -fno-exceptions

--- a/src/src.pro
+++ b/src/src.pro
@@ -25,7 +25,7 @@ win32 {
 
 linux-g++:QMAKE_CXXFLAGS += -fno-exceptions
 
-unix:VERSION = 0.3.1
+unix:VERSION = 0.3.2
 
 MOC_DIR           = tmp
 OBJECTS_DIR       = tmp


### PR DESCRIPTION
Hi all,

we've been using this library in our projects and it has been working greatly.
Unfortunately after upgrading our application from Qt 5.9 to 5.12, the widget where the plot should be is not properly rendered anymore, it is completely blank. We think it is an issue caused by the base class the plots derive from, QGLWidget. That class has been deprecated and it is not supported anymore. New applications are encouraged to use the new class QOpenGLWidget.
As a matter of fact we modified the library to use the new class and the applications is now working as expected.

The library is working in our use cases, but some examples are not working anymore. More work is needed to finalize it, but we do not have enough resources to allocate to this. Hope our effort helps in keeping this lib alive and useful.

We opened an issue about that. See
https://github.com/sintegrial/qwtplot3d/issues/14

Thanks,
Calogero Mauceri